### PR TITLE
Improve size of small text on mobile

### DIFF
--- a/SimplyTransport/lib/settings.py
+++ b/SimplyTransport/lib/settings.py
@@ -21,7 +21,7 @@ class AppSettings(BaseEnvSettings):
     NAME: str = "SimplyTransport"
     LOG_LEVEL: str = "DEBUG"
 
-    VERSION: str = "0.1.0"
+    VERSION: str = "0.1.1" # Version bumping will cache bust static css/js files
     SECRET_KEY: str = "secret"
     LITESTAR_APP: str = "SimplyTransport.app:create_app"
 

--- a/SimplyTransport/lib/settings.py
+++ b/SimplyTransport/lib/settings.py
@@ -21,7 +21,7 @@ class AppSettings(BaseEnvSettings):
     NAME: str = "SimplyTransport"
     LOG_LEVEL: str = "DEBUG"
 
-    VERSION: str = "0.1.1" # Version bumping will cache bust static css/js files
+    VERSION: str = "0.1.1"  # Version bumping will cache bust static css/js files
     SECRET_KEY: str = "secret"
     LITESTAR_APP: str = "SimplyTransport.app:create_app"
 

--- a/SimplyTransport/static/static/style.css
+++ b/SimplyTransport/static/static/style.css
@@ -415,7 +415,17 @@ h3 {
 	}
 
 	.code-highlight {
-		font-size: 0.95rem;
+		font-size: 0.85rem;
+	}
+
+	.pagination-button {
+		font-size: 0.85rem;
+		padding: 0.4rem;
+	}
+
+	.dropdown {
+		font-size: 0.85rem;
+		padding: 0.4rem;
 	}
 
 	.table-search th {

--- a/SimplyTransport/templates/footer.html
+++ b/SimplyTransport/templates/footer.html
@@ -45,6 +45,10 @@
     .content-wrap {
 		padding-bottom: 120px; /* Footer height */
 	}
+
+    .footer-item{
+        padding-right: 0rem;
+    }
 }
 
 


### PR DESCRIPTION
Adds mobile styling for 2 types of buttons

Scales code-highlight class correctly to be 0.05rem greater than standard text instead of 0.15rem

Version bumps to bust cloudflare cache

Remove footer padding on stacked (column) mobile display