### PR TITLE
Store short realtime data buffer

### DIFF
--- a/SimplyTransport/domain/realtime/realtime_schedule/repo.py
+++ b/SimplyTransport/domain/realtime/realtime_schedule/repo.py
@@ -1,5 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, func
+from typing import Tuple
+from sqlalchemy import Result
 
 from SimplyTransport.domain.realtime.stop_time.model import RTStopTimeModel
 from SimplyTransport.domain.realtime.trip.model import RTTripModel
@@ -11,12 +13,45 @@ class RealtimeScheduleRepository:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def get_realtime_schedules_for_trips(self, trips: list[str]):
+    async def get_realtime_schedules_for_trips(self, trips: list[str]) -> Result[Tuple[RTStopTimeModel, RTTripModel]]:
+        """
+        Returns all realtime schedules for the given trips
+
+        Returns the most recent update for each trip
+        """
+        subquery_stop_time = (
+            select(
+                RTStopTimeModel.trip_id,
+                func.max(RTStopTimeModel.created_at).label("max_created_at"),
+            )
+            .group_by(RTStopTimeModel.trip_id)
+            .alias("subquery_stop_time")
+        )
+
+        subquery_trip = (
+            select(
+                RTTripModel.trip_id,
+                func.max(RTTripModel.created_at).label("max_created_at"),
+            )
+            .group_by(RTTripModel.trip_id)
+            .alias("subquery_trip")
+        )
+
         statement = (
-            select(RTStopTimeModel, RTTripModel)
+            select(
+                RTStopTimeModel,
+                RTTripModel,
+            )
             .join(RTTripModel, RTTripModel.trip_id == RTStopTimeModel.trip_id)
+            .join(subquery_stop_time, 
+                (subquery_stop_time.c.trip_id == RTStopTimeModel.trip_id) & 
+                (subquery_stop_time.c.max_created_at == RTStopTimeModel.created_at))
+            .join(subquery_trip, 
+                (subquery_trip.c.trip_id == RTTripModel.trip_id) & 
+                (subquery_trip.c.max_created_at == RTTripModel.created_at))
             .where(RTTripModel.trip_id.in_(trips))
         )
+
         return await self.session.execute(statement)
 
 

--- a/SimplyTransport/domain/realtime/realtime_schedule/repo.py
+++ b/SimplyTransport/domain/realtime/realtime_schedule/repo.py
@@ -13,7 +13,9 @@ class RealtimeScheduleRepository:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def get_realtime_schedules_for_trips(self, trips: list[str]) -> Result[Tuple[RTStopTimeModel, RTTripModel]]:
+    async def get_realtime_schedules_for_trips(
+        self, trips: list[str]
+    ) -> Result[Tuple[RTStopTimeModel, RTTripModel]]:
         """
         Returns all realtime schedules for the given trips
 
@@ -43,12 +45,16 @@ class RealtimeScheduleRepository:
                 RTTripModel,
             )
             .join(RTTripModel, RTTripModel.trip_id == RTStopTimeModel.trip_id)
-            .join(subquery_stop_time, 
-                (subquery_stop_time.c.trip_id == RTStopTimeModel.trip_id) & 
-                (subquery_stop_time.c.max_created_at == RTStopTimeModel.created_at))
-            .join(subquery_trip, 
-                (subquery_trip.c.trip_id == RTTripModel.trip_id) & 
-                (subquery_trip.c.max_created_at == RTTripModel.created_at))
+            .join(
+                subquery_stop_time,
+                (subquery_stop_time.c.trip_id == RTStopTimeModel.trip_id)
+                & (subquery_stop_time.c.max_created_at == RTStopTimeModel.created_at),
+            )
+            .join(
+                subquery_trip,
+                (subquery_trip.c.trip_id == RTTripModel.trip_id)
+                & (subquery_trip.c.max_created_at == RTTripModel.created_at),
+            )
             .where(RTTripModel.trip_id.in_(trips))
         )
 

--- a/SimplyTransport/lib/gtfs_realtime_importers.py
+++ b/SimplyTransport/lib/gtfs_realtime_importers.py
@@ -56,8 +56,12 @@ class RealTimeImporter:
 
         sixty_mins_ago = datetime.now(timezone.utc) - timedelta(minutes=60)
         with session:
-            session.query(RTStopTimeModel).filter(RTStopTimeModel.created_at < sixty_mins_ago, RTStopTimeModel.dataset == self.dataset).delete()
-            session.query(RTTripModel).filter(RTTripModel.created_at < sixty_mins_ago, RTTripModel.dataset == self.dataset).delete()
+            session.query(RTStopTimeModel).filter(
+                RTStopTimeModel.created_at < sixty_mins_ago, RTStopTimeModel.dataset == self.dataset
+            ).delete()
+            session.query(RTTripModel).filter(
+                RTTripModel.created_at < sixty_mins_ago, RTTripModel.dataset == self.dataset
+            ).delete()
             session.commit()
 
     def import_stop_times(self, data: dict) -> int:
@@ -154,12 +158,8 @@ class RealTimeImporter:
                     new_rt_trip = RTTripModel(
                         trip_id=trip.get("trip_id"),
                         route_id=trip.get("route_id"),
-                        start_time=tdc.convert_29_hours_to_24_hours(
-                            trip.get("start_time")
-                        ),
-                        start_date=tdc.convert_joined_date_to_date(
-                            trip.get("start_date")
-                        ),
+                        start_time=tdc.convert_29_hours_to_24_hours(trip.get("start_time")),
+                        start_date=tdc.convert_joined_date_to_date(trip.get("start_date")),
                         schedule_relationship=schedule_relationship,
                         direction=trip.get("direction_id"),
                         entity_id=item.get("id"),

--- a/SimplyTransport/lib/gtfs_realtime_importers.py
+++ b/SimplyTransport/lib/gtfs_realtime_importers.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 import requests
 
 from SimplyTransport.lib.logging import logger
@@ -51,21 +52,21 @@ class RealTimeImporter:
             return None
 
     def clear_table_stop_trip(self):
-        """Clears the table in the database that corresponds to the dataset"""
+        """Clears the table in the database that corresponds to the dataset for rows older than 60 mins"""
 
+        sixty_mins_ago = datetime.now(timezone.utc) - timedelta(minutes=60)
         with session:
-            session.query(RTStopTimeModel).filter(RTStopTimeModel.dataset == self.dataset).delete()
-            session.query(RTTripModel).filter(RTTripModel.dataset == self.dataset).delete()
+            session.query(RTStopTimeModel).filter(RTStopTimeModel.created_at < sixty_mins_ago, RTStopTimeModel.dataset == self.dataset).delete()
+            session.query(RTTripModel).filter(RTTripModel.created_at < sixty_mins_ago, RTTripModel.dataset == self.dataset).delete()
             session.commit()
 
     def import_stop_times(self, data: dict) -> int:
         """Imports the stop times from the dataset into the database"""
 
         stop_time_update_count = sum(
-            len(item["trip_update"]["stop_time_update"])
+            len(item["trip_update"].get("stop_time_update", []))
             for item in data["entity"]
-            if item["trip_update"]["trip"]["schedule_relationship"] != "CANCELED"
-            and item["trip_update"]["trip"]["schedule_relationship"] != "ADDED"
+            if item["trip_update"]["trip"]["schedule_relationship"] not in ["CANCELED", "ADDED"]
         )
         with rp.Progress(*progress_columns) as progress:
             task = progress.add_task("[green]Importing RT Stop Times...", total=stop_time_update_count)
@@ -77,57 +78,46 @@ class RealTimeImporter:
                 trips_in_db = {trip[0] for trip in trips_in_db}
 
                 try:
-                    for item in data["entity"]:
-                        try:
-                            if item["trip_update"]["trip"]["schedule_relationship"] == "CANCELED":
-                                continue  # TODO: Import canceled trips
+                    for item in data.get("entity", []):
+                        trip_update = item.get("trip_update", {})
+                        trip = trip_update.get("trip", {})
+                        schedule_relationship = trip.get("schedule_relationship")
 
-                            if item["trip_update"]["trip"]["schedule_relationship"] == "ADDED":
-                                continue  # TODO: Import added trips
+                        if schedule_relationship in ["CANCELED", "ADDED"]:
+                            continue  # TODO: Import canceled and added trips
 
-                            # Foreign key exceptions
-                            if item["trip_update"]["trip"]["trip_id"] not in trips_in_db:
-                                continue
-
-                            for stop_time in item["trip_update"]["stop_time_update"]:
-                                arrival_delay = None
-                                departure_delay = None
-
-                                if stop_time["schedule_relationship"] == "SKIPPED":
-                                    continue  # TODO: Import skipped stops
-
-                                if "arrival" in stop_time and "delay" in stop_time["arrival"]:
-                                    arrival_delay = stop_time["arrival"]["delay"]
-
-                                if "departure" in stop_time and "delay" in stop_time["departure"]:
-                                    departure_delay = stop_time["departure"]["delay"]
-
-                                new_rt_stop_time = RTStopTimeModel(
-                                    stop_id=stop_time["stop_id"],
-                                    trip_id=item["trip_update"]["trip"]["trip_id"],
-                                    stop_sequence=stop_time["stop_sequence"],
-                                    schedule_relationship=stop_time["schedule_relationship"],
-                                    arrival_delay=arrival_delay,
-                                    departure_delay=departure_delay,
-                                    entity_id=item["id"],
-                                    dataset=self.dataset,
-                                )
-
-                                objects_to_commit.append(new_rt_stop_time)
-                                progress.update(task, advance=1)
-
-                        except KeyError as e:
-                            logger.warning(
-                                f"RealTime: {self.url} returned invalid JSON in stop times: {e} - {item}"
-                            )
+                        # Foreign key exceptions
+                        if trip.get("trip_id") not in trips_in_db:
                             continue
+
+                        for stop_time in trip_update.get("stop_time_update", []):
+                            if stop_time.get("schedule_relationship") == "SKIPPED":
+                                continue  # TODO: Import skipped stops
+
+                            arrival = stop_time.get("arrival", {})
+                            departure = stop_time.get("departure", {})
+
+                            new_rt_stop_time = RTStopTimeModel(
+                                stop_id=stop_time.get("stop_id"),
+                                trip_id=trip.get("trip_id"),
+                                stop_sequence=stop_time.get("stop_sequence"),
+                                schedule_relationship=stop_time.get("schedule_relationship"),
+                                arrival_delay=arrival.get("delay"),
+                                departure_delay=departure.get("delay"),
+                                entity_id=item.get("id"),
+                                dataset=self.dataset,
+                            )
+
+                            objects_to_commit.append(new_rt_stop_time)
+                            progress.update(task, advance=1)
+
                     try:
                         session.bulk_save_objects(objects_to_commit)
                         session.commit()
                     except Exception as e:
                         logger.error(f"RealTime: {self.url} failed to commit stop times: {e}")
-                except KeyError as e:
-                    logger.warning(f"RealTime: {self.url} returned invalid JSON in entitys: {e}")
+                except Exception as e:
+                    logger.warning(f"RealTime: {self.url} returned invalid JSON in entities: {e}")
                     return 0
 
                 return stop_time_update_count
@@ -138,8 +128,7 @@ class RealTimeImporter:
         trip_update_count = sum(
             1
             for item in data["entity"]
-            if item["trip_update"]["trip"]["schedule_relationship"] != "CANCELED"
-            and item["trip_update"]["trip"]["schedule_relationship"] != "ADDED"
+            if item["trip_update"]["trip"]["schedule_relationship"] not in ["CANCELED", "ADDED"]
         )
         with rp.Progress(*progress_columns) as progress:
             task = progress.add_task("[green]Importing RT Trips...", total=trip_update_count)
@@ -150,49 +139,40 @@ class RealTimeImporter:
                 routes_in_db = session.query(RouteModel.id).filter(RouteModel.dataset == self.dataset).all()
                 routes_in_db = {route[0] for route in routes_in_db}
 
+                for item in data.get("entity", []):
+                    trip_update = item.get("trip_update", {})
+                    trip = trip_update.get("trip", {})
+                    schedule_relationship = trip.get("schedule_relationship")
+
+                    if schedule_relationship in ["CANCELED", "ADDED"]:
+                        continue  # TODO: Import canceled and added trips
+
+                    # Foreign key exceptions
+                    if trip.get("route_id") not in routes_in_db:
+                        continue
+
+                    new_rt_trip = RTTripModel(
+                        trip_id=trip.get("trip_id"),
+                        route_id=trip.get("route_id"),
+                        start_time=tdc.convert_29_hours_to_24_hours(
+                            trip.get("start_time")
+                        ),
+                        start_date=tdc.convert_joined_date_to_date(
+                            trip.get("start_date")
+                        ),
+                        schedule_relationship=schedule_relationship,
+                        direction=trip.get("direction_id"),
+                        entity_id=item.get("id"),
+                        dataset=self.dataset,
+                    )
+
+                    objects_to_commit.append(new_rt_trip)
+                    progress.update(task, advance=1)
+
                 try:
-                    for item in data["entity"]:
-                        try:
-                            if item["trip_update"]["trip"]["schedule_relationship"] == "CANCELED":
-                                continue  # TODO: Import canceled trips
+                    session.bulk_save_objects(objects_to_commit)
+                    session.commit()
+                except Exception as e:
+                    logger.error(f"RealTime: {self.url} failed to commit trips: {e}")
 
-                            if item["trip_update"]["trip"]["schedule_relationship"] == "ADDED":
-                                continue  # TODO: Import added trips
-
-                            # Foreign key exceptions
-                            if item["trip_update"]["trip"]["route_id"] not in routes_in_db:
-                                continue
-
-                            new_rt_trip = RTTripModel(
-                                trip_id=item["trip_update"]["trip"]["trip_id"],
-                                route_id=item["trip_update"]["trip"]["route_id"],
-                                start_time=tdc.convert_29_hours_to_24_hours(
-                                    item["trip_update"]["trip"]["start_time"]
-                                ),
-                                start_date=tdc.convert_joined_date_to_date(
-                                    item["trip_update"]["trip"]["start_date"]
-                                ),
-                                schedule_relationship=item["trip_update"]["trip"]["schedule_relationship"],
-                                direction=item["trip_update"]["trip"]["direction_id"],
-                                entity_id=item["id"],
-                                dataset=self.dataset,
-                            )
-
-                            objects_to_commit.append(new_rt_trip)
-                            progress.update(task, advance=1)
-                        except KeyError as e:
-                            logger.warning(
-                                f"RealTime: {self.url} returned invalid JSON in trips: {e} - {item}"
-                            )
-                            continue
-                    try:
-                        session.bulk_save_objects(objects_to_commit)
-                        session.commit()
-                    except Exception as e:
-                        logger.error(f"RealTime: {self.url} failed to commit trips: {e}")
-
-                except KeyError as e:
-                    logger.warning(f"RealTime: {self.url} returned invalid JSON in entitys: {e}")
-                    return 0
-
-                return trip_update_count
+        return trip_update_count

--- a/SimplyTransport/templates/realtime/stop.html
+++ b/SimplyTransport/templates/realtime/stop.html
@@ -71,6 +71,7 @@
              hx-get="/realtime/stop/{{ stop.id }}/schedule"
              hx-trigger="revealed"
              hx-target="#schedule-table"
+             hx-include="[name='day']"
              hx-swap="transition:true">
             <h3 class="h3-table">Set Schedule:</h3>
             <div class="load-with-dropdown">


### PR DESCRIPTION
Instead of clearing and re-writing the table when updating the realtime, a 60 minute bugger is now kept.

Deletes only occur on data created more than 60 mins ago, and when querying the data, the latest update is returned