### PR TITLE
Make gtfs importer async

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ This extends the standard litestar cli. You can view all the commands by just ru
 - [x] Realtime Updater `importrealtime`
 - [x] Stop Feature Importer `importstopfeatures`
 - [x] Create Database tables manually `create_tables`
+- [x] Recreate all database indexes `recreate_indexes`
 
 # Installation
 

--- a/SimplyTransport/cli.py
+++ b/SimplyTransport/cli.py
@@ -2,6 +2,7 @@ import json
 import os
 import time
 import asyncio
+import functools
 
 import geojson
 import click
@@ -12,6 +13,7 @@ from rich.console import Console
 from rich.table import Table
 
 import SimplyTransport.lib.gtfs_importers as imp
+from SimplyTransport.lib.db import services as db_services
 from SimplyTransport.lib.gtfs_realtime_importers import RealTimeImporter
 from SimplyTransport.lib.stop_features_importer import StopFeaturesImporter
 from SimplyTransport.domain.events.repo import create_event_with_session
@@ -31,6 +33,13 @@ def gtfs_directory_validator(dir: str, console: Console):
 
     return dir
 
+# https://github.com/pallets/click/issues/2033
+def make_sync(func):
+    '''Decorator to run async functions in a sync context'''
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(func(*args, **kwargs))
+    return wrapper
 
 class CLIPlugin(CLIPluginProtocol):
     def on_cli_init(self, cli: click.Group) -> None:
@@ -87,7 +96,8 @@ class CLIPlugin(CLIPluginProtocol):
 
         @cli.command(name="importgtfs", help="Imports GTFS data into the database")
         @click.option("-dir", help="Override the directory containing the GTFS data to import")
-        def importgtfs(dir: str):
+        @make_sync
+        async def importgtfs(dir: str):
             """Imports GTFS data into the database"""
 
             start: float = time.perf_counter()
@@ -159,8 +169,11 @@ class CLIPlugin(CLIPluginProtocol):
                     task = progress.add_task("[red]Clearing database table...", total=1)
                     importer.clear_table()
                     progress.update(task, advance=1)
-
-                importer.import_data()
+                
+                if file in ["stop_times.txt", "shapes.txt", "trips.txt"]:
+                    await importer.import_data()
+                else:
+                    importer.import_data()
 
                 finish = time.perf_counter()
                 time_taken = round(finish - file_start, 2)
@@ -176,20 +189,19 @@ class CLIPlugin(CLIPluginProtocol):
                 "totals": attributes_of_total_rows,
                 "total_time_taken(s)": round(total_time_taken, 2),
             }
-            asyncio.run(
-                create_event_with_session(
+            await create_event_with_session(
                     EventType.GTFS_DATABASE_UPDATED,
                     "GTFS static data updated with latest schedules",
                     attributes,
                 )
-            )
             console.print(f"\n[blue]Finished import in {round(finish-start, 2)} second(s)")
 
         @cli.command(name="importrealtime", help="Imports GTFS realtime data into the database")
         @click.option("-url", help="Override the default URL for the GTFS realtime data")
         @click.option("-apikey", help="Override the default API key for the GTFS realtime data")
         @click.option("-dataset", help="Override the default dataset that the data will be saved against")
-        def importrealtime(url: str, apikey: str, dataset: str):
+        @make_sync
+        async def importrealtime(url: str, apikey: str, dataset: str):
             """Imports GTFS realtime data into the database"""
 
             start: float = time.perf_counter()
@@ -244,13 +256,12 @@ class CLIPlugin(CLIPluginProtocol):
                 "total_stop_times": total_stop_times,
                 "time_taken(s)": round(finish - start, 2),
             }
-            asyncio.run(
-                create_event_with_session(
+            await create_event_with_session(
                     EventType.REALTIME_DATABASE_UPDATED,
                     "Realtime database updated with new realtime information",
                     attributes,
                 )
-            )
+            
             console.print(f"\n[blue]Finished import in {round(finish-start, 2)} second(s)")
 
         @cli.command(name="create_tables", help="Creates the database tables")
@@ -260,13 +271,12 @@ class CLIPlugin(CLIPluginProtocol):
             console = Console()
             console.print("Creating database tables...")
 
-            from SimplyTransport.lib.db import services as db_services
-
             db_services.create_database_sync()
 
         @cli.command(name="importstopfeatures", help="Imports stop features into the database")
         @click.option("-dir", help="Override the directory containing the stop feature data to import")
-        def importstopfeatures(dir: str):
+        @make_sync
+        async def importstopfeatures(dir: str):
             """Imports stop features into the database"""
 
             start: float = time.perf_counter()
@@ -330,12 +340,38 @@ class CLIPlugin(CLIPluginProtocol):
                 "time_taken(s)": round(finish - start, 2),
             }
 
-            asyncio.run(
-                create_event_with_session(
+            await create_event_with_session(
                     EventType.STOP_FEATURES_DATABASE_UPDATED,
                     "Stop features database updated with latest stop features",
                     attributes,
                 )
-            )
 
             console.print(f"\n[blue]Finished import in {round(finish-start, 2)} second(s)")
+
+
+        @cli.command(name="recreate_indexes", help="Recreates the indexes on a given table")
+        @click.option("-table", help="The table to recreate the indexes on")
+        def recreate_indexes(table: str):
+            """Recreates the indexes on a given table"""
+
+            console = Console()
+            console.print("Recreating indexes...")
+            if table is None:
+                console.print("[yellow]No table specified to recreate indexes on from the -table argument")
+                response = click.prompt(
+                    "\nYou are about to recreate indexes on all tables. Press 'y' to continue, anything else to abort: ",
+                    type=str,
+                    default="",
+                    show_default=False,
+                )
+                if response != "y":
+                    console.print("[red]Aborting recreate indexes...")
+                    return
+            
+            start = time.perf_counter()
+
+            db_services.recreate_indexes(table)
+
+            finish = time.perf_counter()
+
+            console.print(f"\n[blue]Finished recreating indexes in {round(finish-start, 2)} second(s)")

--- a/SimplyTransport/cli.py
+++ b/SimplyTransport/cli.py
@@ -33,13 +33,17 @@ def gtfs_directory_validator(dir: str, console: Console):
 
     return dir
 
+
 # https://github.com/pallets/click/issues/2033
 def make_sync(func):
-    '''Decorator to run async functions in a sync context'''
+    """Decorator to run async functions in a sync context"""
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return asyncio.run(func(*args, **kwargs))
+
     return wrapper
+
 
 class CLIPlugin(CLIPluginProtocol):
     def on_cli_init(self, cli: click.Group) -> None:
@@ -169,7 +173,7 @@ class CLIPlugin(CLIPluginProtocol):
                     task = progress.add_task("[red]Clearing database table...", total=1)
                     importer.clear_table()
                     progress.update(task, advance=1)
-                
+
                 if file in ["stop_times.txt", "shapes.txt", "trips.txt"]:
                     await importer.import_data()
                 else:
@@ -190,10 +194,10 @@ class CLIPlugin(CLIPluginProtocol):
                 "total_time_taken(s)": round(total_time_taken, 2),
             }
             await create_event_with_session(
-                    EventType.GTFS_DATABASE_UPDATED,
-                    "GTFS static data updated with latest schedules",
-                    attributes,
-                )
+                EventType.GTFS_DATABASE_UPDATED,
+                "GTFS static data updated with latest schedules",
+                attributes,
+            )
             console.print(f"\n[blue]Finished import in {round(finish-start, 2)} second(s)")
 
         @cli.command(name="importrealtime", help="Imports GTFS realtime data into the database")
@@ -257,11 +261,11 @@ class CLIPlugin(CLIPluginProtocol):
                 "time_taken(s)": round(finish - start, 2),
             }
             await create_event_with_session(
-                    EventType.REALTIME_DATABASE_UPDATED,
-                    "Realtime database updated with new realtime information",
-                    attributes,
-                )
-            
+                EventType.REALTIME_DATABASE_UPDATED,
+                "Realtime database updated with new realtime information",
+                attributes,
+            )
+
             console.print(f"\n[blue]Finished import in {round(finish-start, 2)} second(s)")
 
         @cli.command(name="create_tables", help="Creates the database tables")
@@ -341,13 +345,12 @@ class CLIPlugin(CLIPluginProtocol):
             }
 
             await create_event_with_session(
-                    EventType.STOP_FEATURES_DATABASE_UPDATED,
-                    "Stop features database updated with latest stop features",
-                    attributes,
-                )
+                EventType.STOP_FEATURES_DATABASE_UPDATED,
+                "Stop features database updated with latest stop features",
+                attributes,
+            )
 
             console.print(f"\n[blue]Finished import in {round(finish-start, 2)} second(s)")
-
 
         @cli.command(name="recreate_indexes", help="Recreates the indexes on a given table")
         @click.option("-table", help="The table to recreate the indexes on")
@@ -367,7 +370,7 @@ class CLIPlugin(CLIPluginProtocol):
                 if response != "y":
                     console.print("[red]Aborting recreate indexes...")
                     return
-            
+
             start = time.perf_counter()
 
             db_services.recreate_indexes(table)

--- a/SimplyTransport/lib/db/services.py
+++ b/SimplyTransport/lib/db/services.py
@@ -27,9 +27,9 @@ def create_database_sync() -> None:
         raise e
 
 
-def recreate_indexes(table_name:str|None = None):
+def recreate_indexes(table_name: str | None = None):
     """Recreate all indexes"""
-    
+
     metadata = MetaData()
     metadata.reflect(bind=engine)
 
@@ -46,6 +46,6 @@ def recreate_indexes(table_name:str|None = None):
         table = metadata.tables[table_name]
         indexes = list(table.indexes)
         for index in indexes:
-                index.drop(bind=engine)
+            index.drop(bind=engine)
         for index in indexes:
             index.create(bind=engine)

--- a/SimplyTransport/lib/db/services.py
+++ b/SimplyTransport/lib/db/services.py
@@ -1,5 +1,7 @@
 import SimplyTransport.lib.db.database as _db
 from litestar.contrib.sqlalchemy.base import UUIDBase
+from sqlalchemy import MetaData
+from SimplyTransport.lib.db.database import engine
 
 
 async def create_database() -> None:
@@ -23,3 +25,27 @@ def create_database_sync() -> None:
             f"\nDatabase connection refused. Please ensure the database is running and accessible.\nURL: {_db.sqlalchemy_config.get_engine().url}\n"
         )
         raise e
+
+
+def recreate_indexes(table_name:str|None = None):
+    """Recreate all indexes"""
+    
+    metadata = MetaData()
+    metadata.reflect(bind=engine)
+
+    if table_name is None:
+        # recreate index on every table
+        for table_name in metadata.tables:
+            table = metadata.tables[table_name]
+            indexes = list(table.indexes)
+            for index in indexes:
+                index.drop(bind=engine)
+            for index in indexes:
+                index.create(bind=engine)
+    else:
+        table = metadata.tables[table_name]
+        indexes = list(table.indexes)
+        for index in indexes:
+                index.drop(bind=engine)
+        for index in indexes:
+            index.create(bind=engine)

--- a/SimplyTransport/lib/gtfs_importers.py
+++ b/SimplyTransport/lib/gtfs_importers.py
@@ -250,13 +250,13 @@ class TripImporter(GTFSImporter):
 
         q = asyncio.Queue(maxsize=3)
         number_of_consumers = 2
-        producer = asyncio.create_task(self.producer(q,number_of_consumers))
+        producer = asyncio.create_task(self.producer(q, number_of_consumers))
         tasks = [asyncio.create_task(self.consumer(q)) for _ in range(number_of_consumers)]
         tasks.append(producer)
 
         await asyncio.gather(*tasks)
 
-    async def producer(self, q:asyncio.Queue,number_of_consumers:int):
+    async def producer(self, q: asyncio.Queue, number_of_consumers: int):
         batch_count = 0
         objects_to_commit = []
 
@@ -292,7 +292,7 @@ class TripImporter(GTFSImporter):
             for _ in range(number_of_consumers):
                 await q.put(None)
 
-    async def consumer(self, q:asyncio.Queue):
+    async def consumer(self, q: asyncio.Queue):
         async with async_session_factory() as session:
             while True:
                 objects_to_commit = await q.get()
@@ -388,19 +388,19 @@ class ShapeImporter(GTFSImporter):
 
     def __str__(self) -> str:
         return "ShapeImporter"
-    
+
     async def import_data(self):
         """Imports the data from the csv.DictReader object into the database"""
 
         q = asyncio.Queue(maxsize=3)
         number_of_consumers = 2
-        producer = asyncio.create_task(self.producer(q,number_of_consumers))
+        producer = asyncio.create_task(self.producer(q, number_of_consumers))
         tasks = [asyncio.create_task(self.consumer(q)) for _ in range(number_of_consumers)]
         tasks.append(producer)
 
         await asyncio.gather(*tasks)
 
-    async def producer(self, q:asyncio.Queue,number_of_consumers:int):
+    async def producer(self, q: asyncio.Queue, number_of_consumers: int):
         batch_count = 0
         objects_to_commit = []
 
@@ -413,9 +413,7 @@ class ShapeImporter(GTFSImporter):
                     lat=float(row["shape_pt_lat"]),
                     lon=float(row["shape_pt_lon"]),
                     sequence=int(row["shape_pt_sequence"]),
-                    distance=float(row["shape_dist_traveled"])
-                    if row["shape_dist_traveled"] != ""
-                    else None,
+                    distance=float(row["shape_dist_traveled"]) if row["shape_dist_traveled"] != "" else None,
                     dataset=self.dataset,
                 )
 
@@ -435,7 +433,7 @@ class ShapeImporter(GTFSImporter):
             for _ in range(number_of_consumers):
                 await q.put(None)
 
-    async def consumer(self, q:asyncio.Queue):
+    async def consumer(self, q: asyncio.Queue):
         async with async_session_factory() as session:
             while True:
                 objects_to_commit = await q.get()
@@ -466,19 +464,19 @@ class StopTimeImporter(GTFSImporter):
 
     def __str__(self) -> str:
         return "StopTimeImporter"
-    
+
     async def import_data(self):
         """Imports the data from the csv.DictReader object into the database"""
 
         q = asyncio.Queue(maxsize=3)
         number_of_consumers = 2
-        producer = asyncio.create_task(self.producer(q,number_of_consumers))
+        producer = asyncio.create_task(self.producer(q, number_of_consumers))
         tasks = [asyncio.create_task(self.consumer(q)) for _ in range(number_of_consumers)]
         tasks.append(producer)
 
         await asyncio.gather(*tasks)
 
-    async def producer(self, q:asyncio.Queue,number_of_consumers:int):
+    async def producer(self, q: asyncio.Queue, number_of_consumers: int):
         batch_count = 0
         objects_to_commit = []
 
@@ -533,7 +531,7 @@ class StopTimeImporter(GTFSImporter):
             for _ in range(number_of_consumers):
                 await q.put(None)
 
-    async def consumer(self, q:asyncio.Queue):
+    async def consumer(self, q: asyncio.Queue):
         async with async_session_factory() as session:
             while True:
                 objects_to_commit = await q.get()

--- a/SimplyTransport/lib/gtfs_importers.py
+++ b/SimplyTransport/lib/gtfs_importers.py
@@ -1,4 +1,5 @@
 import csv
+import asyncio
 
 import rich.progress as rp
 
@@ -11,7 +12,7 @@ from SimplyTransport.domain.trip.model import TripModel
 from SimplyTransport.domain.stop.model import StopModel
 from SimplyTransport.domain.shape.model import ShapeModel
 from SimplyTransport.domain.stop_times.model import StopTimeModel
-from SimplyTransport.lib.db.database import session
+from SimplyTransport.lib.db.database import session, async_session_factory
 from SimplyTransport.lib import time_date_conversions as tdc
 
 progress_columns = (
@@ -235,7 +236,7 @@ class RouteImporter(GTFSImporter):
 
 
 class TripImporter(GTFSImporter):
-    def __init__(self, reader: csv.DictReader, row_count: int, dataset: str, batchsize: int = 10000):
+    def __init__(self, reader: csv.DictReader, row_count: int, dataset: str, batchsize: int = 50000):
         self.reader = reader
         self.row_count = row_count
         self.dataset = dataset
@@ -244,39 +245,66 @@ class TripImporter(GTFSImporter):
     def __str__(self) -> str:
         return "TripImporter"
 
-    def import_data(self):
+    async def import_data(self):
         """Imports the data from the csv.DictReader object into the database"""
+
+        q = asyncio.Queue(maxsize=3)
+        number_of_consumers = 2
+        producer = asyncio.create_task(self.producer(q,number_of_consumers))
+        tasks = [asyncio.create_task(self.consumer(q)) for _ in range(number_of_consumers)]
+        tasks.append(producer)
+
+        await asyncio.gather(*tasks)
+
+    async def producer(self, q:asyncio.Queue,number_of_consumers:int):
+        batch_count = 0
+        objects_to_commit = []
 
         with rp.Progress(*progress_columns) as progress:
             task = progress.add_task("[green]Importing Trips...", total=self.row_count)
-            batch_count = 0
-            objects_to_commit = []
 
-            with session:
-                for row in self.reader:
-                    new_trip = TripModel(
-                        id=row["trip_id"],
-                        route_id=row["route_id"],
-                        service_id=row["service_id"],
-                        shape_id=row["shape_id"],
-                        headsign=row["trip_headsign"],
-                        short_name=row["trip_short_name"],
-                        direction=int(row["direction_id"]),
-                        block_id=row["block_id"],
-                        dataset=self.dataset,
-                    )
-                    objects_to_commit.append(new_trip)
-                    batch_count += 1
-                    progress.update(task, advance=1)
+            for row in self.reader:
+                new_trip = TripModel(
+                    id=row["trip_id"],
+                    route_id=row["route_id"],
+                    service_id=row["service_id"],
+                    shape_id=row["shape_id"],
+                    headsign=row["trip_headsign"],
+                    short_name=row["trip_short_name"],
+                    direction=int(row["direction_id"]),
+                    block_id=row["block_id"],
+                    dataset=self.dataset,
+                )
 
-                    if batch_count >= self.batchsize:
-                        session.bulk_save_objects(objects_to_commit)
-                        objects_to_commit = []
-                        batch_count = 0
+                objects_to_commit.append(new_trip)
+                batch_count += 1
+                progress.update(task, advance=1)
 
-                if objects_to_commit:
-                    session.bulk_save_objects(objects_to_commit)
-                session.commit()
+                if batch_count >= self.batchsize:
+                    await q.put(objects_to_commit)
+                    objects_to_commit = []
+                    batch_count = 0
+
+            if objects_to_commit:
+                await q.put(objects_to_commit)
+
+            # Signal the consumer that the producer is done
+            for _ in range(number_of_consumers):
+                await q.put(None)
+
+    async def consumer(self, q:asyncio.Queue):
+        async with async_session_factory() as session:
+            while True:
+                objects_to_commit = await q.get()
+
+                # If the producer is done, break the loop
+                if objects_to_commit is None:
+                    break
+
+                session.add_all(objects_to_commit)
+                await session.commit()
+
+                q.task_done()
 
     def clear_table(self):
         """Clears the table in the database that corresponds to the file"""
@@ -360,40 +388,66 @@ class ShapeImporter(GTFSImporter):
 
     def __str__(self) -> str:
         return "ShapeImporter"
-
-    def import_data(self):
+    
+    async def import_data(self):
         """Imports the data from the csv.DictReader object into the database"""
+
+        q = asyncio.Queue(maxsize=3)
+        number_of_consumers = 2
+        producer = asyncio.create_task(self.producer(q,number_of_consumers))
+        tasks = [asyncio.create_task(self.consumer(q)) for _ in range(number_of_consumers)]
+        tasks.append(producer)
+
+        await asyncio.gather(*tasks)
+
+    async def producer(self, q:asyncio.Queue,number_of_consumers:int):
+        batch_count = 0
+        objects_to_commit = []
 
         with rp.Progress(*progress_columns) as progress:
             task = progress.add_task("[green]Importing Shapes...", total=self.row_count)
-            batch_count = 0
-            objects_to_commit = []
 
-            with session:
-                for row in self.reader:
-                    new_shape = ShapeModel(
-                        shape_id=row["shape_id"],
-                        lat=float(row["shape_pt_lat"]),
-                        lon=float(row["shape_pt_lon"]),
-                        sequence=int(row["shape_pt_sequence"]),
-                        distance=float(row["shape_dist_traveled"])
-                        if row["shape_dist_traveled"] != ""
-                        else None,
-                        dataset=self.dataset,
-                    )
+            for row in self.reader:
+                new_shape = ShapeModel(
+                    shape_id=row["shape_id"],
+                    lat=float(row["shape_pt_lat"]),
+                    lon=float(row["shape_pt_lon"]),
+                    sequence=int(row["shape_pt_sequence"]),
+                    distance=float(row["shape_dist_traveled"])
+                    if row["shape_dist_traveled"] != ""
+                    else None,
+                    dataset=self.dataset,
+                )
 
-                    objects_to_commit.append(new_shape)
-                    batch_count += 1
-                    progress.update(task, advance=1)
+                objects_to_commit.append(new_shape)
+                batch_count += 1
+                progress.update(task, advance=1)
 
-                    if batch_count >= self.batchsize:
-                        session.bulk_save_objects(objects_to_commit)
-                        objects_to_commit = []
-                        batch_count = 0
+                if batch_count >= self.batchsize:
+                    await q.put(objects_to_commit)
+                    objects_to_commit = []
+                    batch_count = 0
 
-                if objects_to_commit:
-                    session.bulk_save_objects(objects_to_commit)
-                session.commit()
+            if objects_to_commit:
+                await q.put(objects_to_commit)
+
+            # Signal the consumer that the producer is done
+            for _ in range(number_of_consumers):
+                await q.put(None)
+
+    async def consumer(self, q:asyncio.Queue):
+        async with async_session_factory() as session:
+            while True:
+                objects_to_commit = await q.get()
+
+                # If the producer is done, break the loop
+                if objects_to_commit is None:
+                    break
+
+                session.add_all(objects_to_commit)
+                await session.commit()
+
+                q.task_done()
 
     def clear_table(self):
         """Clears the table in the database that corresponds to the file"""
@@ -412,60 +466,86 @@ class StopTimeImporter(GTFSImporter):
 
     def __str__(self) -> str:
         return "StopTimeImporter"
-
-    def import_data(self):
+    
+    async def import_data(self):
         """Imports the data from the csv.DictReader object into the database"""
+
+        q = asyncio.Queue(maxsize=3)
+        number_of_consumers = 2
+        producer = asyncio.create_task(self.producer(q,number_of_consumers))
+        tasks = [asyncio.create_task(self.consumer(q)) for _ in range(number_of_consumers)]
+        tasks.append(producer)
+
+        await asyncio.gather(*tasks)
+
+    async def producer(self, q:asyncio.Queue,number_of_consumers:int):
+        batch_count = 0
+        objects_to_commit = []
 
         with rp.Progress(*progress_columns) as progress:
             task = progress.add_task("[green]Importing Stop Times...", total=self.row_count)
-            batch_count = 0
-            objects_to_commit = []
 
-            with session:
-                for row in self.reader:
-                    arrival_time = tdc.convert_29_hours_to_24_hours(row["arrival_time"])
-                    departure_time = tdc.convert_29_hours_to_24_hours(row["departure_time"])
+            for row in self.reader:
+                arrival_time = tdc.convert_29_hours_to_24_hours(row["arrival_time"])
+                departure_time = tdc.convert_29_hours_to_24_hours(row["departure_time"])
 
-                    if row["pickup_type"] == "":
-                        pickup_type = None
-                    else:
-                        pickup_type = int(row["pickup_type"])
+                if row["pickup_type"] == "":
+                    pickup_type = None
+                else:
+                    pickup_type = int(row["pickup_type"])
 
-                    if row["drop_off_type"] == "":
-                        drop_off_type = None
-                    else:
-                        drop_off_type = int(row["drop_off_type"])
+                if row["drop_off_type"] == "":
+                    drop_off_type = None
+                else:
+                    drop_off_type = int(row["drop_off_type"])
 
-                    if row["timepoint"] == "":
-                        timepoint = None
-                    else:
-                        timepoint = int(row["timepoint"])
+                if row["timepoint"] == "":
+                    timepoint = None
+                else:
+                    timepoint = int(row["timepoint"])
 
-                    new_stop_time = StopTimeModel(
-                        trip_id=row["trip_id"],
-                        arrival_time=arrival_time,
-                        departure_time=departure_time,
-                        stop_id=row["stop_id"],
-                        stop_sequence=int(row["stop_sequence"]),
-                        stop_headsign=row["stop_headsign"],
-                        pickup_type=pickup_type,
-                        dropoff_type=drop_off_type,
-                        timepoint=timepoint,
-                        dataset=self.dataset,
-                    )
+                new_stop_time = StopTimeModel(
+                    trip_id=row["trip_id"],
+                    arrival_time=arrival_time,
+                    departure_time=departure_time,
+                    stop_id=row["stop_id"],
+                    stop_sequence=int(row["stop_sequence"]),
+                    stop_headsign=row["stop_headsign"],
+                    pickup_type=pickup_type,
+                    dropoff_type=drop_off_type,
+                    timepoint=timepoint,
+                    dataset=self.dataset,
+                )
 
-                    objects_to_commit.append(new_stop_time)
-                    batch_count += 1
-                    progress.update(task, advance=1)
+                objects_to_commit.append(new_stop_time)
+                batch_count += 1
+                progress.update(task, advance=1)
 
-                    if batch_count >= self.batchsize:
-                        session.bulk_save_objects(objects_to_commit)
-                        objects_to_commit = []
-                        batch_count = 0
+                if batch_count >= self.batchsize:
+                    await q.put(objects_to_commit)
+                    objects_to_commit = []
+                    batch_count = 0
 
-                if objects_to_commit:
-                    session.bulk_save_objects(objects_to_commit)
-                session.commit()
+            if objects_to_commit:
+                await q.put(objects_to_commit)
+
+            # Signal the consumer that the producer is done
+            for _ in range(number_of_consumers):
+                await q.put(None)
+
+    async def consumer(self, q:asyncio.Queue):
+        async with async_session_factory() as session:
+            while True:
+                objects_to_commit = await q.get()
+
+                # If the producer is done, break the loop
+                if objects_to_commit is None:
+                    break
+
+                session.add_all(objects_to_commit)
+                await session.commit()
+
+                q.task_done()
 
     def clear_table(self):
         """Clears the table in the database that corresponds to the file"""


### PR DESCRIPTION
Use Queues and async to speed up imports.

A producer will generate objects from the csv and add them to a queue to be commited to the DB.
A consumer will pop off the queue and commit the objects to the DB.

The queue will be async so new objects can be created while awaiting the database commits.