### PR TITLE
Revert "Concurrent queries on main page"

### DIFF
--- a/SimplyTransport/controllers/root.py
+++ b/SimplyTransport/controllers/root.py
@@ -1,10 +1,9 @@
-import asyncio
 from litestar import Controller, Response, get
 from litestar.response import Template, File
 from litestar.di import Provide
 from ..domain.maps.maps import Map
 from ..domain.services.map_service import MapService
-from ..domain.events.repo import get_single_pretty_event_with_session
+from ..domain.events.repo import EventRepository, provide_event_repo
 from ..domain.events.event_types import EventType
 from litestar.exceptions import HTTPException
 from ..lib.db.services import test_database_connection
@@ -19,6 +18,7 @@ __all__ = [
 
 class RootController(Controller):
     dependencies = {
+        "event_repo": Provide(provide_event_repo),
         "map_service": Provide(MapService, sync_to_thread=False),
         "map": Provide(Map, sync_to_thread=False),
     }
@@ -26,18 +26,18 @@ class RootController(Controller):
     @get("/", cache=60)
     async def root(
         self,
+        event_repo: EventRepository,
     ) -> Template:
 
-        # This creates independant sessions so the queries can be run concurrently
-        coroutines = [
-            get_single_pretty_event_with_session(EventType.GTFS_DATABASE_UPDATED),
-            get_single_pretty_event_with_session(EventType.REALTIME_DATABASE_UPDATED),
-            get_single_pretty_event_with_session(EventType.REALTIME_VEHICLES_DATABASE_UPDATED),
-            get_single_pretty_event_with_session(EventType.STOP_FEATURES_DATABASE_UPDATED),
-        ]
-
-        gtfs_updated_event, realtime_updated_event, vehicles_updated_event, stop_features_updated_event = (
-            await asyncio.gather(*coroutines)
+        gtfs_updated_event = await event_repo.get_single_pretty_event_by_type(EventType.GTFS_DATABASE_UPDATED)
+        realtime_updated_event = await event_repo.get_single_pretty_event_by_type(
+            EventType.REALTIME_DATABASE_UPDATED
+        )
+        vehicles_updated_event = await event_repo.get_single_pretty_event_by_type(
+            EventType.REALTIME_VEHICLES_DATABASE_UPDATED
+        )
+        stop_features_updated_event = await event_repo.get_single_pretty_event_by_type(
+            EventType.STOP_FEATURES_DATABASE_UPDATED
         )
 
         return Template(

--- a/SimplyTransport/domain/events/repo.py
+++ b/SimplyTransport/domain/events/repo.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import datetime, timedelta, UTC
 from litestar.contrib.sqlalchemy.repository import SQLAlchemyAsyncRepository
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -102,11 +101,3 @@ async def create_event_with_session(
     async with async_session_factory() as db_session:
         event_repo = await provide_event_repo(db_session=db_session)
         await event_repo.create_event(event_type, description, attributes, expiry_time)
-
-
-async def get_single_pretty_event_with_session(
-    event_type: EventType,
-):
-    async with async_session_factory() as db_session:
-        event_repo = await provide_event_repo(db_session=db_session)
-        return await event_repo.get_single_pretty_event_by_type(event_type)


### PR DESCRIPTION
Doesnt really help as the cloudflare cold start eclipses the performance benefit, and this is cached for 60 seconds after a request anyway