### PR TITLE
Use sets for lookups

### DIFF
--- a/SimplyTransport/lib/gtfs_realtime_importers.py
+++ b/SimplyTransport/lib/gtfs_realtime_importers.py
@@ -90,12 +90,12 @@ class RealTimeImporter:
             result_trips = await session.execute(
                 select(TripModel.id).filter(TripModel.dataset == self.dataset).distinct()
             )
-            trips_in_db = result_trips.scalars().all()
+            trips_in_db = {trip for trip in result_trips.scalars()}
 
             result_stops = await session.execute(
                 select(StopModel.id).filter(StopModel.dataset == self.dataset).distinct()
             )
-            stops_in_db = result_stops.scalars().all()
+            stops_in_db = {stop for stop in result_stops.scalars()}
 
             try:
                 for item in data.get("entity", []):
@@ -161,11 +161,11 @@ class RealTimeImporter:
             result_routes = await session.execute(
                 select(RouteModel.id).filter(RouteModel.dataset == self.dataset).distinct()
             )
-            routes_in_db = result_routes.scalars().all()
+            routes_in_db = {route for route in result_routes.scalars()}
             result_trips = await session.execute(
                 select(TripModel.id).filter(TripModel.dataset == self.dataset).distinct()
             )
-            trips_in_db = result_trips.scalars().all()
+            trips_in_db = {trip for trip in result_trips.scalars()}
 
             for item in data.get("entity", []):
                 trip_update = item.get("trip_update", {})

--- a/SimplyTransport/lib/gtfs_realtime_importers.py
+++ b/SimplyTransport/lib/gtfs_realtime_importers.py
@@ -90,12 +90,12 @@ class RealTimeImporter:
             result_trips = await session.execute(
                 select(TripModel.id).filter(TripModel.dataset == self.dataset).distinct()
             )
-            trips_in_db = {trip for trip in result_trips.scalars()}
+            trips_in_db = set(result_trips.scalars())
 
             result_stops = await session.execute(
                 select(StopModel.id).filter(StopModel.dataset == self.dataset).distinct()
             )
-            stops_in_db = {stop for stop in result_stops.scalars()}
+            stops_in_db = set(result_stops.scalars())
 
             try:
                 for item in data.get("entity", []):
@@ -161,11 +161,11 @@ class RealTimeImporter:
             result_routes = await session.execute(
                 select(RouteModel.id).filter(RouteModel.dataset == self.dataset).distinct()
             )
-            routes_in_db = {route for route in result_routes.scalars()}
+            routes_in_db = set(result_routes.scalars())
             result_trips = await session.execute(
                 select(TripModel.id).filter(TripModel.dataset == self.dataset).distinct()
             )
-            trips_in_db = {trip for trip in result_trips.scalars()}
+            trips_in_db = set(result_trips.scalars())
 
             for item in data.get("entity", []):
                 trip_update = item.get("trip_update", {})


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the GTFS real-time importers by replacing list-based lookups with set-based lookups for trips, stops, and routes. This change aims to improve the performance of the import operations.

- **Enhancements**:
    - Replaced list-based lookups with set-based lookups for trips, stops, and routes to improve performance in the GTFS real-time importers.

<!-- Generated by sourcery-ai[bot]: end summary -->