### PR TITLE
Change statistic sorting

### DIFF
--- a/SimplyTransport/controllers/stats.py
+++ b/SimplyTransport/controllers/stats.py
@@ -30,7 +30,7 @@ class StatsController(Controller):
 
         stats = await stats_repo.get_statistics_most_recent_by_type(StatisticType.GTFS_RECORD_COUNTS)
         stats_with_percentages = stats_service.convert_stats_to_stats_with_percentage_totals(stats)
-        stats_with_percentages = stats_service.sort_stats_by_percentage(stats_with_percentages)
+        stats_with_percentages = stats_service.sort_stats_by_value(stats_with_percentages)
 
         return Template(
             template_name="stats/static_data.html",
@@ -46,13 +46,13 @@ class StatsController(Controller):
         routes_with_percentages = stats_service.convert_stats_to_stats_with_percentage_totals(
             routes, total_row_key="Total Routes"
         )
-        routes_with_percentages = stats_service.sort_stats_by_percentage(routes_with_percentages)
+        routes_with_percentages = stats_service.sort_stats_by_value(routes_with_percentages)
 
         trips = await stats_repo.get_statistics_most_recent_by_type(StatisticType.OPERATOR_TRIP_COUNTS)
         trips_with_percentages = stats_service.convert_stats_to_stats_with_percentage_totals(
             trips, total_row_key="Total Trips"
         )
-        trips_with_percentages = stats_service.sort_stats_by_percentage(trips_with_percentages)
+        trips_with_percentages = stats_service.sort_stats_by_value(trips_with_percentages)
 
         return Template(
             template_name="stats/operator_data.html",
@@ -75,7 +75,7 @@ class StatsController(Controller):
         stats_with_percentages = stats_service.convert_stats_to_stats_with_percentage_totals(
             stats, total_row_key="Total Stops", total_override=total_stop_count
         )
-        stats_with_percentages = stats_service.sort_stats_by_percentage(stats_with_percentages)
+        stats_with_percentages = stats_service.sort_stats_by_value(stats_with_percentages)
 
         return Template(
             template_name="stats/stop_features_data.html",

--- a/SimplyTransport/domain/services/statistics_service.py
+++ b/SimplyTransport/domain/services/statistics_service.py
@@ -99,11 +99,11 @@ class StatisticsService:
             stats_with_percentages.append((percentage_stat))
         return stats_with_percentages
 
-    def sort_stats_by_percentage(
+    def sort_stats_by_value(
         self, stats: List[DatabaseStatisticWithPercentage], descending: bool = True
     ) -> List[DatabaseStatisticWithPercentage]:
         """
-        Sorts a list of DatabaseStatisticWithPercentage objects based on their percentage value.
+        Sorts a list of DatabaseStatisticWithPercentage objects based on their value.
 
         Args:
             stats (List[DatabaseStatisticWithPercentage]): The list of statistics to be sorted.
@@ -113,7 +113,7 @@ class StatisticsService:
         Returns:
             List[DatabaseStatisticWithPercentage]: The sorted list of statistics.
         """
-        return sorted(stats, key=lambda x: x.percentage, reverse=descending)
+        return sorted(stats, key=lambda x: x.value, reverse=descending)
 
 
 async def provide_statistics_service(db_session: AsyncSession) -> StatisticsService:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the statistics sorting method to sort by value instead of percentage across various statistics endpoints.

Enhancements:
- Change sorting method for statistics from percentage-based to value-based in the statistics service.

<!-- Generated by sourcery-ai[bot]: end summary -->