### PR TITLE
Timeseries API

### DIFF
--- a/SimplyTransport/controllers/__init__.py
+++ b/SimplyTransport/controllers/__init__.py
@@ -15,6 +15,7 @@ from .api import (
     map,
     statistics,
     events as eventsAPI,
+    delays,
 )
 from ..lib.openapi.tags import Tags
 
@@ -128,6 +129,12 @@ def create_api_router() -> Router:
         route_handlers=[eventsAPI.EventsController],
     )
 
+    delays_route_handler = Router(
+        path="/delays",
+        tags=[tags.DELAYS.name],
+        route_handlers=[delays.DelaysController],
+    )
+
     return Router(
         path="/api/v1",
         route_handlers=[
@@ -144,5 +151,6 @@ def create_api_router() -> Router:
             maps_route_handler,
             statistics_route_handler,
             events_route_handler,
+            delays_route_handler,
         ],
     )

--- a/SimplyTransport/controllers/api/delays.py
+++ b/SimplyTransport/controllers/api/delays.py
@@ -33,10 +33,10 @@ class DelaysController(Controller):
         repo: TSStopTimeRepository,
         scheduled_time: str = Parameter(required=True, description="Format: HH:MM:SS"),
     ) -> TS_StopTimeDelay:
-        
+
         scheduled_time_parsed = time.fromisoformat(scheduled_time)
         result = await repo.get_delay_on_stop_on_route_on_time(route_code, stop_id, scheduled_time_parsed)
-        
+
         if not result:
             raise NotFoundException(detail=f"Delays not found for {stop_id}, {route_code}, {scheduled_time}")
         return result

--- a/SimplyTransport/controllers/api/delays.py
+++ b/SimplyTransport/controllers/api/delays.py
@@ -36,10 +36,8 @@ class DelaysController(Controller):
         try:
             scheduled_time_parsed = time.fromisoformat(scheduled_time)
         except ValueError:
-            raise ValidationException(
-                detail="Invalid scheduled time format. Use HH:MM:SS"
-            )
-        
+            raise ValidationException(detail="Invalid scheduled time format. Use HH:MM:SS")
+
         result = await repo.get_delay_on_stop_on_route_on_time(route_code, stop_id, scheduled_time_parsed)
 
         if not result:

--- a/SimplyTransport/controllers/api/delays.py
+++ b/SimplyTransport/controllers/api/delays.py
@@ -1,0 +1,42 @@
+from datetime import time
+from litestar import Controller, get
+from litestar.di import Provide
+from litestar.exceptions import NotFoundException
+from litestar.params import Parameter
+
+from ...timescale.ts_stop_times.model import TS_StopTimeDelay
+from ...timescale.ts_stop_times.repo import provide_ts_stop_time_repo, TSStopTimeRepository
+from ...lib.cache_keys import CacheKeys, key_builder_from_path
+
+__all__ = ["DelaysController"]
+
+
+class DelaysController(Controller):
+    dependencies = {"repo": Provide(provide_ts_stop_time_repo)}
+
+    @get(
+        "/{stop_id:str}/{route_code:str}/{scheduled_time:str}",
+        cache=600,
+        cache_key_builder=key_builder_from_path(
+            CacheKeys.DELAYS_SPECIFIC_KEY_TEMPLATE,
+            "stop_id",
+            "route_code",
+            "scheduled_time",
+        ),
+        summary="Get delay on stop on route on time",
+        raises=[NotFoundException],
+    )
+    async def get__delay_on_stop_on_route_on_time(
+        self,
+        stop_id: str,
+        route_code: str,
+        repo: TSStopTimeRepository,
+        scheduled_time: str = Parameter(required=True, description="Format: HH:MM:SS"),
+    ) -> TS_StopTimeDelay:
+        
+        scheduled_time_parsed = time.fromisoformat(scheduled_time)
+        result = await repo.get_delay_on_stop_on_route_on_time(route_code, stop_id, scheduled_time_parsed)
+        
+        if not result:
+            raise NotFoundException(detail=f"Delays not found for {stop_id}, {route_code}, {scheduled_time}")
+        return result

--- a/SimplyTransport/lib/cache_keys.py
+++ b/SimplyTransport/lib/cache_keys.py
@@ -29,6 +29,14 @@ class CacheKeys(Enum):
     STATIC_MAP_STOP_DELETE_ALL_KEY_TEMPLATE = "*static_map:stop:*"
     STATIC_MAP_STOP_DELETE_KEY_TEMPLATE = "*static_map:stop:{map_type}"
 
+    # Delays
+    DELAYS_SPECIFIC_KEY_TEMPLATE = (
+        "delays_specific:{stop_id}:{route_code}:{scheduled_time}"
+    )
+    DELAYS_SPECIFIC_DELETE_ALL_KEY_TEMPLATE = "*delays_specific:*"
+    DELAYS_SPECIFIC_DELETE_KEY_TEMPLATE = "*delays_specific:{stop_id}:{route_code}:*"
+
+
 
 def key_builder_from_path(template: CacheKeys, *args):
     """

--- a/SimplyTransport/lib/cache_keys.py
+++ b/SimplyTransport/lib/cache_keys.py
@@ -30,12 +30,9 @@ class CacheKeys(Enum):
     STATIC_MAP_STOP_DELETE_KEY_TEMPLATE = "*static_map:stop:{map_type}"
 
     # Delays
-    DELAYS_SPECIFIC_KEY_TEMPLATE = (
-        "delays_specific:{stop_id}:{route_code}:{scheduled_time}"
-    )
+    DELAYS_SPECIFIC_KEY_TEMPLATE = "delays_specific:{stop_id}:{route_code}:{scheduled_time}"
     DELAYS_SPECIFIC_DELETE_ALL_KEY_TEMPLATE = "*delays_specific:*"
     DELAYS_SPECIFIC_DELETE_KEY_TEMPLATE = "*delays_specific:{stop_id}:{route_code}:*"
-
 
 
 def key_builder_from_path(template: CacheKeys, *args):

--- a/SimplyTransport/lib/openapi/tags.py
+++ b/SimplyTransport/lib/openapi/tags.py
@@ -54,6 +54,10 @@ class Tags:
         name="Events",
         description="Events are records of tthings that have happened in the system",
     )
+    DELAYS = Tag(
+        name="Delays",
+        description="Delays are records of when a vehicle is late or early",
+    )
 
     @classmethod
     def list_all_tags(cls) -> list[Tag]:

--- a/SimplyTransport/timescale/ts_stop_times/model.py
+++ b/SimplyTransport/timescale/ts_stop_times/model.py
@@ -36,7 +36,7 @@ class TS_StopTimeDelay(BaseModel):
     avg: int
     max: int
     min: int
-    standard_deviation : float
+    standard_deviation: float
     median: int
     p75: int
     p90: int

--- a/SimplyTransport/timescale/ts_stop_times/model.py
+++ b/SimplyTransport/timescale/ts_stop_times/model.py
@@ -30,3 +30,14 @@ class TS_StopTime(BaseModel):
     route_code: str
     scheduled_time: time
     delay_in_seconds: int
+
+
+class TS_StopTimeDelay(BaseModel):
+    avg: int
+    max: int
+    min: int
+    standard_deviation : float
+    median: int
+    p75: int
+    p90: int
+    samples: int

--- a/SimplyTransport/timescale/ts_stop_times/repo.py
+++ b/SimplyTransport/timescale/ts_stop_times/repo.py
@@ -8,7 +8,9 @@ from .model import TS_StopTimeDelay, TS_StopTimeModel
 class TSStopTimeRepository(SQLAlchemyAsyncRepository[TS_StopTimeModel]):
     """TSStopTime repository."""
 
-    async def get_delay_on_stop_on_route_on_time(self, route_code:str, stop_id: str, scheduled_time: time) -> TS_StopTimeDelay | None:
+    async def get_delay_on_stop_on_route_on_time(
+        self, route_code: str, stop_id: str, scheduled_time: time
+    ) -> TS_StopTimeDelay | None:
         """
         Retrieves delay statistics for a specific stop on a specific route at a given scheduled time.
         Args:
@@ -20,7 +22,8 @@ class TSStopTimeRepository(SQLAlchemyAsyncRepository[TS_StopTimeModel]):
                                       otherwise None.
         """
 
-        statement = text("""
+        statement = text(
+            """
         SELECT 
             AVG(delay_in_seconds) as avg_delay,
             MAX(delay_in_seconds) as max_delay,
@@ -34,7 +37,8 @@ class TSStopTimeRepository(SQLAlchemyAsyncRepository[TS_StopTimeModel]):
         WHERE route_code = :route_code
           AND stop_id = :stop_id
           AND scheduled_time = :scheduled_time;
-        """)
+        """
+        )
 
         params = {
             "route_code": route_code,
@@ -50,15 +54,13 @@ class TSStopTimeRepository(SQLAlchemyAsyncRepository[TS_StopTimeModel]):
                 avg=int(row.avg_delay),
                 max=int(row.max_delay),
                 min=int(row.min_delay),
-                standard_deviation=round(float(row.stddev_delay),2)
-                if row.stddev_delay is not None
-                else 0.0,
+                standard_deviation=round(float(row.stddev_delay), 2) if row.stddev_delay is not None else 0.0,
                 median=int(row.median_delay),
                 p75=int(row.p75_delay),
                 p90=int(row.p90_delay),
                 samples=row.samples,
             )
-        
+
         return None
 
     model_type = TS_StopTimeModel

--- a/SimplyTransport/timescale/ts_stop_times/repo.py
+++ b/SimplyTransport/timescale/ts_stop_times/repo.py
@@ -1,10 +1,65 @@
+from datetime import time
 from litestar.contrib.sqlalchemy.repository import SQLAlchemyAsyncRepository
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
-from .model import TS_StopTimeModel
+from .model import TS_StopTimeDelay, TS_StopTimeModel
 
 
 class TSStopTimeRepository(SQLAlchemyAsyncRepository[TS_StopTimeModel]):
     """TSStopTime repository."""
+
+    async def get_delay_on_stop_on_route_on_time(self, route_code:str, stop_id: str, scheduled_time: time) -> TS_StopTimeDelay | None:
+        """
+        Retrieves delay statistics for a specific stop on a specific route at a given scheduled time.
+        Args:
+            route_code (str): The code of the route.
+            stop_id (str): The ID of the stop.
+            scheduled_time (time): The scheduled time of the stop.
+        Returns:
+            TS_StopTimeDelay | None: An instance of TS_StopTimeDelay containing delay statistics if data is available,
+                                      otherwise None.
+        """
+
+        statement = text("""
+        SELECT 
+            AVG(delay_in_seconds) as avg_delay,
+            MAX(delay_in_seconds) as max_delay,
+            MIN(delay_in_seconds) as min_delay,
+            STDDEV(delay_in_seconds) as stddev_delay,
+            PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY delay_in_seconds) as median_delay,
+            PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY delay_in_seconds) as p75_delay,
+            PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY delay_in_seconds) as p90_delay,
+            COUNT(*) as samples
+        FROM ts_stop_times
+        WHERE route_code = :route_code
+          AND stop_id = :stop_id
+          AND scheduled_time = :scheduled_time;
+        """)
+
+        params = {
+            "route_code": route_code,
+            "stop_id": stop_id,
+            "scheduled_time": scheduled_time,
+        }
+
+        result = await self.session.execute(statement=statement, params=params)
+        row = result.fetchone()
+
+        if row and row.samples > 0:
+            return TS_StopTimeDelay(
+                avg=int(row.avg_delay),
+                max=int(row.max_delay),
+                min=int(row.min_delay),
+                standard_deviation=round(float(row.stddev_delay),2)
+                if row.stddev_delay is not None
+                else 0.0,
+                median=int(row.median_delay),
+                p75=int(row.p75_delay),
+                p90=int(row.p90_delay),
+                samples=row.samples,
+            )
+        
+        return None
 
     model_type = TS_StopTimeModel
 


### PR DESCRIPTION
## Summary by Sourcery

Add a new API endpoint to provide delay statistics for specific stops and routes at scheduled times, including caching and documentation updates.

New Features:
- Introduce a new API endpoint to retrieve delay statistics for a specific stop on a specific route at a given scheduled time.
- Add a new data model `TS_StopTimeDelay` to represent delay statistics including average, maximum, minimum, standard deviation, median, 75th percentile, 90th percentile, and sample count.

Enhancements:
- Add caching for the new delay statistics endpoint with a specific cache key template for efficient retrieval.

Documentation:
- Update API documentation to include the new 'Delays' tag, describing the new endpoint for delay statistics.