### PR TITLE
Historical Delays for routes UI

### DIFF
--- a/SimplyTransport/controllers/__init__.py
+++ b/SimplyTransport/controllers/__init__.py
@@ -1,6 +1,6 @@
 from litestar import Router
 
-from . import root, search, realtime, events, maps, stats
+from . import root, search, realtime, events, maps, stats, delays
 from .api import (
     agency,
     calendar,
@@ -15,7 +15,7 @@ from .api import (
     map,
     statistics,
     events as eventsAPI,
-    delays,
+    delays as delaysAPI,
 )
 from ..lib.openapi.tags import Tags
 
@@ -49,6 +49,12 @@ def create_views_router() -> Router:
         include_in_schema=False,
     )
 
+    delays_route_handler = Router(
+        path="/delays",
+        route_handlers=[delays.DelaysController],
+        include_in_schema=False,
+    )
+
     static_route_handler = Router(
         path="/stats",
         route_handlers=[stats.StatsController],
@@ -63,6 +69,7 @@ def create_views_router() -> Router:
             realtime_route_handler,
             events_route_handler,
             maps_route_handler,
+            delays_route_handler,
             static_route_handler,
         ],
     )
@@ -132,7 +139,7 @@ def create_api_router() -> Router:
     delays_route_handler = Router(
         path="/delays",
         tags=[tags.DELAYS.name],
-        route_handlers=[delays.DelaysController],
+        route_handlers=[delaysAPI.DelaysController],
     )
 
     return Router(

--- a/SimplyTransport/controllers/api/delays.py
+++ b/SimplyTransport/controllers/api/delays.py
@@ -17,7 +17,7 @@ class DelaysController(Controller):
 
     @get(
         "/{stop_id:str}/{route_code:str}/{scheduled_time:str}/aggregated",
-        cache=600,
+        cache=86400,
         cache_key_builder=key_builder_from_path(
             CacheKeys.Delays.DELAYS_AGGREGATED_SPECIFIC_KEY_TEMPLATE,
             "stop_id",
@@ -54,7 +54,7 @@ class DelaysController(Controller):
 
     @get(
         "/{stop_id:str}/{route_code:str}/{scheduled_time:str}",
-        cache=600,
+        cache=86400,
         cache_key_builder=key_builder_from_path(
             CacheKeys.Delays.DELAYS_SPECIFIC_KEY_TEMPLATE,
             "stop_id",
@@ -93,7 +93,7 @@ class DelaysController(Controller):
 
     @get(
         "/{stop_id:str}/{route_code:str}/{scheduled_time:str}/truncated",
-        cache=600,
+        cache=86400,
         cache_key_builder=key_builder_from_path(
             CacheKeys.Delays.DELAYS_SPECIFIC_SLIM_KEY_TEMPLATE,
             "stop_id",
@@ -129,7 +129,7 @@ class DelaysController(Controller):
 
     @get(
         "/{route_code:str}/aggregated",
-        cache=600,
+        cache=86400,
         cache_key_builder=key_builder_from_path(
             CacheKeys.Delays.DELAYS_AGGREGATED_ROUTE_KEY_TEMPLATE,
             "route_code",

--- a/SimplyTransport/controllers/delays.py
+++ b/SimplyTransport/controllers/delays.py
@@ -1,0 +1,34 @@
+from litestar import Controller, get
+from litestar.di import Provide
+from litestar.response import Template
+
+from SimplyTransport.lib.cache_keys import CacheKeys, key_builder_from_path
+from SimplyTransport.timescale.ts_stop_times.repo import TSStopTimeRepository, provide_ts_stop_time_repo
+
+__all__ = [
+    "DelaysController",
+]
+
+
+class DelaysController(Controller):
+    dependencies = {"repo": Provide(provide_ts_stop_time_repo)}
+
+    @get(
+        "/route/{route_code:str}",
+        cache=86400,
+        cache_key_builder=key_builder_from_path(
+            CacheKeys.Delays.DELAYS_HTML_ROUTE_KEY_TEMPLATE,
+            "route_code"
+        ),
+    )
+    async def delays_route(
+        self,
+        route_code: str,
+        repo: TSStopTimeRepository,
+    ) -> Template:
+        
+        result = await repo.get_aggregated_delay_on_stop_on_route_on_time(route_code=route_code)
+
+        return Template(
+            template_name="/delays/routes/route.html", context={"delay": result}
+        )

--- a/SimplyTransport/controllers/delays.py
+++ b/SimplyTransport/controllers/delays.py
@@ -17,8 +17,7 @@ class DelaysController(Controller):
         "/route/{route_code:str}",
         cache=86400,
         cache_key_builder=key_builder_from_path(
-            CacheKeys.Delays.DELAYS_HTML_ROUTE_KEY_TEMPLATE,
-            "route_code"
+            CacheKeys.Delays.DELAYS_HTML_ROUTE_KEY_TEMPLATE, "route_code"
         ),
     )
     async def delays_route(
@@ -26,9 +25,7 @@ class DelaysController(Controller):
         route_code: str,
         repo: TSStopTimeRepository,
     ) -> Template:
-        
+
         result = await repo.get_aggregated_delay_on_stop_on_route_on_time(route_code=route_code)
 
-        return Template(
-            template_name="/delays/routes/route.html", context={"delay": result}
-        )
+        return Template(template_name="/delays/routes/route.html", context={"delay": result})

--- a/SimplyTransport/controllers/root.py
+++ b/SimplyTransport/controllers/root.py
@@ -31,7 +31,7 @@ class RootController(Controller):
         "map": Provide(Map, sync_to_thread=False),
     }
 
-    @get("/", cache=60)
+    @get("/", cache=120)
     async def root(
         self,
         event_repo: EventRepository,
@@ -48,6 +48,10 @@ class RootController(Controller):
             EventType.STOP_FEATURES_DATABASE_UPDATED
         )
 
+        delays_recorded_event = await event_repo.get_single_pretty_event_by_type(
+            EventType.RECORD_TS_STOP_TIMES
+        )
+
         return Template(
             template_name="index.html",
             context={
@@ -55,6 +59,7 @@ class RootController(Controller):
                 "realtime_updated": realtime_updated_event,
                 "vehicles_updated": vehicles_updated_event,
                 "stop_features_updated": stop_features_updated_event,
+                "delays_recorded": delays_recorded_event,
             },
         )
 
@@ -86,6 +91,10 @@ class RootController(Controller):
     @get("/routes")
     async def route(self) -> Template:
         return Template("gtfs_search/route_search.html")
+    
+    @get("/delays-explained")
+    async def delays_explained(self) -> Template:
+        return Template("delays/explained.html")
 
     @get("/maps")
     async def maps(self, agency_repo: AgencyRepository) -> Template:

--- a/SimplyTransport/controllers/root.py
+++ b/SimplyTransport/controllers/root.py
@@ -91,7 +91,7 @@ class RootController(Controller):
     @get("/routes")
     async def route(self) -> Template:
         return Template("gtfs_search/route_search.html")
-    
+
     @get("/delays-explained")
     async def delays_explained(self) -> Template:
         return Template("delays/explained.html")

--- a/SimplyTransport/lib/cache_keys.py
+++ b/SimplyTransport/lib/cache_keys.py
@@ -55,6 +55,9 @@ class CacheKeys:
         DELAYS_AGGREGATED_ROUTE_KEY_TEMPLATE = "delays_aggregated_route:{route_code}"
         DELAYS_AGGREGATED_ROUTE_DELETE_ALL_KEY_TEMPLATE = "*delays_aggregated_route:*"
         DELAYS_AGGREGATED_ROUTE_DELETE_KEY_TEMPLATE = "*delays_aggregated_route:{route_code}"
+        DELAYS_HTML_ROUTE_KEY_TEMPLATE = "delays_html_route:{route_code}"
+        DELAYS_HTML_ROUTE_DELETE_ALL_KEY_TEMPLATE = "*delays_html_route:*"
+        DELAYS_HTML_ROUTE_DELETE_KEY_TEMPLATE = "*delays_html_route:{route_code}"
 
 
 def key_builder_from_path(template: StrEnum, *args):

--- a/SimplyTransport/static/static/down-arrow.svg
+++ b/SimplyTransport/static/static/down-arrow.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800px" height="800px" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="10" fill="#233150"/>
+    <path d="M12 16.414l-5.707-5.707 1.414-1.414L12 13.586l4.293-4.293 1.414 1.414L12 16.414z" fill="#FFFFFF"/>
+</svg>

--- a/SimplyTransport/static/static/style.css
+++ b/SimplyTransport/static/static/style.css
@@ -174,7 +174,7 @@ h3 {
 	border-radius: 0.5rem;
 	padding: 0.9rem;
 	background-color: var(--bg-color-bump);
-	min-width: fit-content;
+	overflow-x: auto;
 	border: 1px solid var(--bg-color-bump-border);
 }
 
@@ -269,7 +269,7 @@ h3 {
 .search-box {
 	border-radius: 0.3rem;
 	font-size: 1rem;
-	padding: 0.7rem;
+	padding: 0.6rem;
 	outline: none;
 	border: 3px solid var(--bg-color-highlight);
 	background-color: var(--bg-color);
@@ -371,6 +371,10 @@ h3 {
 	justify-items: start;
 	gap: var(--gap);
 	overflow: hidden;
+}
+
+.data-updates-2-columns {
+	grid-template-columns: 1fr 1fr;
 }
 
 .data-updates > div {
@@ -538,6 +542,29 @@ h3 {
 		padding-right: 0.9rem;
 		padding-bottom: 0.4rem;
 		padding-left: 0.9rem;
+	}
+
+	.search-box {
+		font-size: 0.9rem;
+		padding: 0.5rem;
+	}
+
+	.bottom-margin {
+		margin-bottom: 0.8rem;
+	}
+
+	.table-search-top-text-pad {
+		padding-bottom: 0.5rem;
+	}
+
+	.h2-table {
+		margin-top: 0.3rem;
+		margin-bottom: 0.8rem;
+	}
+
+	.h3-table {
+		margin-top: 0.18rem;
+		margin-bottom: 0.8rem;
 	}
 
 	.dropdown {

--- a/SimplyTransport/templates/about.html
+++ b/SimplyTransport/templates/about.html
@@ -25,22 +25,23 @@
             SimplyTransport is constantly growing its featureset. It provides an API for accessing formatted GTFS data, with the
             ability to query specific subsets of data. This functionality is not
             available in the limited official APIs. Additional data models have also
-            been defined to make working with the datasets more accessible.
+            been defined to expand the feature set offered by the standard GTFS format.
         </p>
         <p class="dense-text">Some key features include:</p>
         <ul class="dense-text">
             <li>Searching routes / stops</li>
-            <li>Viewing static schedules / trips</li>
-            <li>Always updating Realtime ETAs</li>
+            <li>Viewing schedules / trips</li>
+            <li>Constantly updating Realtime ETAs</li>
             <li>Maps of routes and stops</li>
             <li>Stop Features per stop ( shelter, realtime display, bins etc )</li>
             <li>Statistics on routes and stops</li>
-            <li>Open API spec for most datasets</li>
+            <li>Historical data</li>
+            <li>Open API support</li>
         </ul>
         <h2>Technology</h2>
         <p class="dense-text">
-            SimplyTransport is built using a variety of technologies to ensure
-            efficiency and reliability. Further technical details are available on the
+            SimplyTransport is built using a variety of technologies.
+            Further technical details are available on the
             <a class="link-style"
                target="_blank"
                href="https://github.com/ANIALLATOR114/SimplyTransport">GitHub repository</a>.

--- a/SimplyTransport/templates/delays/explained.html
+++ b/SimplyTransport/templates/delays/explained.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block title %}
+    {{ request.app.openapi_config.title
+    }} - Delay Data Explained
+{% endblock title %}
+{% block content %}
+    <div class="narrow-container">
+        <h1>Historical Delay Data</h1>
+        <p class="dense-text">
+            Every single minute, SimplyTransport is collecting and aggregating delay data from the Realtime API.
+            This data is stored and then used to calculate historical statistics over time.
+        </p>
+        <p class="dense-text">
+            This data is inserted into a database with millions of entries, which is is growing all the time with thousands, or tens of thousands, of new data points every hour.
+        </p>
+        <p class="dense-text">
+            You can see the number of samples being recorded in the <a class="link-style" href="/events">Events</a> page which records each update under <span class="code-highlight">timeseries.delays.recorded</span>.
+        </p>
+        <h2>Definitions</h2>
+        <p class="dense-text">
+            <span class="code-highlight">Unit of Measurement</span> Unless otherwise specified, all values are recorded in seconds.
+        </p>
+        <p class="dense-text">
+            <span class="code-highlight">Average</span> The average delay across all samples.
+        </p>
+        <p class="dense-text">
+            <span class="code-highlight">50th Percentile</span> The delay value below which 50% of the samples fall.
+        </p>
+        <p class="dense-text">
+            <span class="code-highlight">75th Percentile</span> The delay value below which 75% of the samples fall.
+        </p>
+        <p class="dense-text">
+            <span class="code-highlight">90th Percentile</span> The delay value below which 90% of the samples fall.
+        </p>
+        <p class="dense-text">
+            <span class="code-highlight">Standard Deviation</span> A measure of the amount of variation or dispersion of a set of values.
+        </p>
+        <p class="dense-text">
+            <span class="code-highlight">Minimum</span> The single minimum delay value recorded.
+        </p>
+        <p class="dense-text">
+            <span class="code-highlight">Maximum</span> The single maximum delay value recorded.
+        </p>
+        <p class="dense-text">
+            <span class="code-highlight">Samples</span> The total number of samples recorded.
+        </p>
+        <p class="dense-text">
+            <span class="code-highlight">TimeStamp</span> The exact time at which the data was recorded.
+        </p>
+        <p class="dense-text">
+            <span class="code-highlight">Delay in Seconds</span> The negative or positive delay value in seconds.
+        </p>
+        <h2>Limitations</h2>
+        <p class="dense-text">
+            The data is collected from the Realtime API, which is subject to the accuracy of the data provided by the transport operators (TFI).
+        </p>
+        <p class="dense-text">
+            Not every vehicle is equipped with a GPS tracker, so some vehicles may not be represented in the data or may have only partial data available.
+        </p>
+    </div>
+{% endblock content %}

--- a/SimplyTransport/templates/delays/routes/route.html
+++ b/SimplyTransport/templates/delays/routes/route.html
@@ -1,0 +1,29 @@
+<h2 class="no-top-margin">Historical Delays</h2>
+{% if delay is none %}
+    <p class="dense-text">No historical data available for this route.</p>
+{% else %}
+    <p class="dense-text">
+        The following data is based on historical delays aggregated across the entire route. All values in seconds.
+    </p>
+    <div class="data-updates data-updates-2-columns">
+        <div class="dense-text">Average</div>
+        <div class="dense-text">{{ delay.avg }}</div>
+        <div class="dense-text">50th Percentile</div>
+        <div class="dense-text">{{ delay.p50 }}</div>
+        <div class="dense-text">75th Percentile</div>
+        <div class="dense-text">{{ delay.p75 }}</div>
+        <div class="dense-text">90th Percentile</div>
+        <div class="dense-text">{{ delay.p90 }}</div>
+        <div class="dense-text">Standard Deviation</div>
+        <div class="dense-text">{{ delay.standard_deviation }}</div>
+        <div class="dense-text">Minimum</div>
+        <div class="dense-text">{{ delay.min }}</div>
+        <div class="dense-text">Maximum</div>
+        <div class="dense-text">{{ delay.max }}</div>
+        <div class="dense-text">Samples</div>
+        <div class="dense-text">{{ delay.samples }}</div>
+        <div class="dense-text">
+            <a class="link-style" href="/delays-explained">Data Explained</a>
+        </div>
+    </div>
+{% endif %}

--- a/SimplyTransport/templates/delays/routes/route_loader.html
+++ b/SimplyTransport/templates/delays/routes/route_loader.html
@@ -1,0 +1,13 @@
+<div hx-get="/delays/route/{{ route.short_name }}"
+     hx-trigger="load"
+     hx-target="#route-delay-element"
+     hx-indicator="#delay-loader"
+     hx-swap="transition:true">
+    <div id="route-delay-element"></div>
+    <img class="map-loader"
+         id="delay-loader"
+         src="/static/loader.svg"
+         width="100%"
+         height="80px"
+         alt="Loading spinner">
+</div>

--- a/SimplyTransport/templates/index.html
+++ b/SimplyTransport/templates/index.html
@@ -42,6 +42,15 @@
                     {% endif %}
                 </div>
                 <div class="dense-text">Every minute</div>
+                <div class="dense-text">Recording Delays</div>
+                <div class="dense-text">
+                    {% if delays_recorded %}
+                        {{ delays_recorded.created_at_pretty }}
+                    {% else %}
+                        Unknown
+                    {% endif %}
+                </div>
+                <div class="dense-text">Every minute</div>
                 <div class="dense-text">GTFS Static Schedules</div>
                 <div class="dense-text">
                     {% if gtfs_updated %}

--- a/SimplyTransport/templates/navbar.html
+++ b/SimplyTransport/templates/navbar.html
@@ -5,7 +5,7 @@
         display: flex;
         align-items: center;
         position: sticky;
-        top:0;
+        top: 0;
         background-color: var(--bg-color);
         z-index: 999;
     }
@@ -44,7 +44,24 @@
         align-items: center;
     }
 
-    .nav-button{
+    .nav-dropdown-logo {
+        width: 2.5rem;
+        display: flex;
+        align-items: center;
+        display: none;
+        position: absolute;
+        bottom: 0;
+        left: 50%;
+        transform: translate(-50%, 50%);
+        cursor: pointer;
+        transition : transform 0.3s ease-in-out;
+    }
+
+    .nav-dropdown-logo.rotate {
+        transform: translate(-50%, 50%) rotate(180deg);
+    }
+
+    .nav-button {
         border-radius: 10px;
         background: transparent;
         padding: 0.6rem;
@@ -59,12 +76,12 @@
         cursor: pointer;
     }
 
-    .nav-button:hover{
+    .nav-button:hover {
         background-color: var(--bg-color-highlight);
         transition: all 0.2s ease-in-out;
     }
 
-    .nav-link{
+    .nav-link {
         font-weight: 500;
         font-size: 1.1rem;
         padding: 0.6rem;
@@ -82,12 +99,12 @@
         color: var(--font-color);
     }
 
-    .nav-link:hover{
+    .nav-link:hover {
         background-color: var(--bg-color-highlight);
         transition: all 0.2s ease-in-out;
     }
 
-    .version-tag{
+    .version-tag {
         font-weight: 500;
         font-size: 1.0rem;
         padding-top: 0.1rem;
@@ -105,12 +122,12 @@
     }
 
     @media screen and (max-width: 750px) {
-	.navbar-flex {
+    .navbar-flex {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         justify-items: center;
         gap: 0.6rem;
-	}
+    }
 
     .navbar-flex > :first-child {
         grid-column: span 2;
@@ -127,12 +144,28 @@
     .nav-link {
         font-size: 1rem;
     }
+
     .navbar {
         position: relative;
     }
 
     .navbar-head {
         font-size: 1.2rem;
+    }
+
+    .nav-dropdown-logo {
+        display: block;
+    }
+
+    .nav-dropdown {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.4s ease-out;
+    }
+
+    .nav-dropdown.show {
+        max-height: 200px;
+        transition: max-height 0.4s ease-in;
     }
 }
 </style>
@@ -171,35 +204,42 @@
                     </button>
                 </a>
             </div>
-            <div class="navbar-item">
+            <div class="navbar-item nav-dropdown">
                 <a href="/maps">
                     <button class="nav-link">
                         <span class="nav-link-text">Maps</span>
                     </button>
                 </a>
             </div>
-            <div class="navbar-item">
+            <div class="navbar-item nav-dropdown">
                 <a href="/stats">
                     <button class="nav-link">
                         <span class="nav-link-text">Stats</span>
                     </button>
                 </a>
             </div>
-            <div class="navbar-item">
+            <div class="navbar-item nav-dropdown">
                 <a href="/apidocs">
                     <button class="nav-link">
                         <span class="nav-link-text">Api Docs</span>
                     </button>
                 </a>
             </div>
-            <div class="navbar-item">
+            <div class="navbar-item nav-dropdown">
                 <a href="/events">
                     <button class="nav-link">
                         <span class="nav-link-text">Events</span>
                     </button>
                 </a>
             </div>
-            <div class="navbar-item">
+            <div class="navbar-item nav-dropdown">
+                <a href="/delays-explained">
+                    <button class="nav-link">
+                        <span class="nav-link-text">Delays</span>
+                    </button>
+                </a>
+            </div>
+            <div class="navbar-item nav-dropdown">
                 <a href="/about">
                     <button class="nav-link">
                         <span class="nav-link-text">About</span>
@@ -207,5 +247,22 @@
                 </a>
             </div>
         </div>
+        <div class="nav-dropdown-logo" id="nav-dropdown-button">
+            <img src="/static/down-arrow.svg"
+                 onclick="toggleDropdown()"
+                 alt="search"
+                 width="100%"
+                 height="100%">
+        </div>
     </div>
 </nav>
+<script>
+    function toggleDropdown() {
+        const dropdownContent = document.getElementsByClassName('nav-dropdown');
+        const dropdownButton = document.getElementById('nav-dropdown-button');
+        for (let i = 0; i < dropdownContent.length; i++) {
+            dropdownContent[i].classList.toggle('show');
+        }
+        dropdownButton.classList.toggle('rotate');
+    }
+</script>

--- a/SimplyTransport/templates/realtime/route.html
+++ b/SimplyTransport/templates/realtime/route.html
@@ -29,6 +29,7 @@
             {% endif %}
         </h2>
         <div class="inner-container inner-container-expand">{% include "/maps/realtime/route.html" %}</div>
+        <div class="inner-container">{% include "/delays/routes/route_loader.html" %}</div>
         <div class="inner-container">
             <h3 class="h3-table">Stops:</h3>
             <table class="table-search table-sortable" aria-label="Stops on route">

--- a/SimplyTransport/templates/realtime/stop.html
+++ b/SimplyTransport/templates/realtime/stop.html
@@ -27,6 +27,9 @@
             <div class="flex-separate table-search-top-text-pad">
                 <span class="dense-text">Showing <span class="word-highlight">{{ start_time_difference }}</span> and <span class="word-highlight">+{{ end_time_difference }}</span> mins</span><span class="code-highlight">{{ current_time.strftime("%H:%M:%S") }}</span>
             </div>
+            <div class="bottom-margin">
+                <input class="search-box" placeholder="Filter by route...">
+            </div>
             <table class="table-search" aria-label="Realtime">
                 <thead>
                     <tr>

--- a/SimplyTransport/templates/speculations.html
+++ b/SimplyTransport/templates/speculations.html
@@ -3,7 +3,7 @@
     "prerender": [
         {
         "source" : "list",
-        "urls": ["routes", "stops"],
+        "urls": ["/routes", "/stops"],
         "eagerness" : "eager"
         },
         {

--- a/tests/integration/test_website_200s.py
+++ b/tests/integration/test_website_200s.py
@@ -1,7 +1,17 @@
 import pytest
 from litestar.testing import TestClient
 
-urls = ["/", "/events/", "/stops/", "/routes/", "/apidocs", "/about", "/maps"]
+urls = [
+    "/",
+    "/stops/",
+    "/routes/",
+    "/maps",
+    "/stats",
+    "/apidocs",
+    "/events/",
+    "/delays-explained",
+    "/about",
+]
 
 
 @pytest.mark.parametrize("url", urls)


### PR DESCRIPTION
# Historical delays for routes 
![image](https://github.com/user-attachments/assets/07ad205a-5f19-41e2-9956-f6dbf048c030)
![image](https://github.com/user-attachments/assets/1c8cd89a-423b-4094-8d35-8bac53159ee9)


Adds UI support to display historical data for routes. 

UI support for individual times will follow next.

Also adds an explainer page.