### PR TITLE
Dependabot | Pre commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    target-branch: "main"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "deps"
+      include: "scope"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,8 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.10.0 # Use the latest stable version
+    rev: 24.10.0
     hooks:
       - id: black
         args: [--line-length=110]
         files: ^(SimplyTransport|tests)/
+        stages: [commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0 # Use the latest stable version
+    hooks:
+      - id: black
+        args: [--line-length=110]
+        files: ^(SimplyTransport|tests)/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,4 +5,4 @@ repos:
       - id: black
         args: [--line-length=110]
         files: ^(SimplyTransport|tests)/
-        stages: [commit]
+        stages: [pre-commit]

--- a/README.md
+++ b/README.md
@@ -454,3 +454,33 @@ coverage html --show-contexts
 ```
 
 This will generate a htmlcov directory in the root directory where you can open index.html to view the report in your browser.
+
+## Pre-commit Hooks
+
+The hooks are configured to run Black with the same settings as the CI pipeline.
+
+### Installation
+
+Install development dependencies:
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+### Usage
+
+The hooks will run automatically on every commit. Black will automatically format your code and include the changes in your commit - no need to stage the reformatted files again.
+
+### Current Hooks
+
+- **black**: Python code formatter (auto-formats code)
+  - Line length: 110 characters
+  - Targets: SimplyTransport/ and tests/ directories
+  - Auto-adds reformatted files to your commit
+
+### Configuration Files
+
+- `.pre-commit-config.yaml`: Pre-commit hook configuration
+- `requirements-dev.txt`: Development dependencies including pre-commit
+- `.github/workflows/format_code.yaml`: GitHub Action that runs the same formatting in CI

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pre-commit>=3.5.0
+black>=24.10.0 


### PR DESCRIPTION
## Summary by Sourcery

Add pre-commit hooks to automatically format Python code using Black.

Build:
- Add `requirements-dev.txt` to manage development dependencies.

CI:
- Add pre-commit configuration file.