### PR TITLE
Specific delays for trips at stops

### DIFF
--- a/SimplyTransport/controllers/api/delays.py
+++ b/SimplyTransport/controllers/api/delays.py
@@ -8,7 +8,12 @@ from litestar.params import Parameter
 from ...lib.cache_keys import CacheKeys, key_builder_from_path
 from ...lib.time_date_conversions import validate_time_range
 from ...timescale.ts_stop_times.model import TS_StopTime, TS_StopTimeDelayAggregated, TS_StopTimeForGraph
-from ...timescale.ts_stop_times.repo import MAXIMUM_TIMESTAMP, TSStopTimeRepository, provide_ts_stop_time_repo
+from ...timescale.ts_stop_times.repo import (
+    MAXIMUM_LIMIT,
+    MAXIMUM_TIMESTAMP,
+    TSStopTimeRepository,
+    provide_ts_stop_time_repo,
+)
 
 __all__ = ["DelaysController"]
 
@@ -68,7 +73,7 @@ class DelaysController(Controller):
         ),
         summary="Get delay data for a route on a stop on a time",
         description=f"All queries will be limited to {MAXIMUM_TIMESTAMP.strftime('%Y-%m-%d')} "
-        f"onwards or 730 records",
+        f"onwards or {MAXIMUM_LIMIT} records",
         raises=[ValidationException],
     )
     async def get_delay_on_stop_on_route_on_time(
@@ -102,7 +107,7 @@ class DelaysController(Controller):
         ),
         summary="Get truncated delay data for a route on a stop on a time",
         description=f"All queries will be limited to {MAXIMUM_TIMESTAMP.strftime('%Y-%m-%d')} "
-        f"onwards or 730 records",
+        f"onwards or {MAXIMUM_LIMIT} records",
         raises=[ValidationException],
     )
     async def get_truncated_delay_on_stop_on_route_on_time(

--- a/SimplyTransport/domain/maps/maps.py
+++ b/SimplyTransport/domain/maps/maps.py
@@ -157,7 +157,7 @@ class Map:
             border: 2px solid rgba(0,0,0,0.3);
             border-radius: 4px;
             cursor: pointer;
-            font-weight: bold;
+            font-weight: 700;
         }
         .toggle-all-layers:hover {
             background: #f4f4f4;

--- a/SimplyTransport/lib/settings.py
+++ b/SimplyTransport/lib/settings.py
@@ -10,7 +10,7 @@ class AppSettings(BaseSettings):
     NAME: str = "SimplyTransport"
     LOG_LEVEL: str = "DEBUG"
 
-    VERSION: str = "0.8.1"  # Version bumping will cache bust static css/js files
+    VERSION: str = "0.9.0"  # Version bumping will cache bust static css/js files
     SECRET_KEY: str = "secret"
     LITESTAR_APP: str = "SimplyTransport.app:create_app"
 

--- a/SimplyTransport/static/static/delays.css
+++ b/SimplyTransport/static/static/delays.css
@@ -1,0 +1,41 @@
+.delays-specific-toggle-button {
+	border-radius: 0.3rem;
+	font-size: 0.9rem;
+	padding-top: 0.2rem;
+	padding-right: 0.8rem;
+	padding-bottom: 0.1rem;
+	padding-left: 0.8rem;
+	border: none;
+	background-color: var(--bg-color-highlight);
+	color: var(--font-color);
+	transition: all 0.2s ease-in-out;
+	cursor: pointer;
+}
+
+.delays-specific-toggle-button:hover {
+	background-color: var(--bg-color-light);
+}
+
+.delays-specific-stats-row {
+	display: flex;
+	justify-content: center;
+}
+
+.delays-specific-stats-detail-cell {
+	cursor: text;
+	background-color: var(--bg-color-bump);
+	overflow: hidden;
+	transform-origin: top;
+	transition: transform 0.2s ease-in-out;
+	transform: scaleY(0);
+}
+
+.delays-specific-stats-detail-cell.expanded {
+	transform: scaleY(1);
+}
+
+.delays-specific-stats-grid {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	row-gap: 8px;
+}

--- a/SimplyTransport/static/static/load-me.svg
+++ b/SimplyTransport/static/static/load-me.svg
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="256px" height="256px" viewBox="6 4 12.00 18.00" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#ffffff" stroke-width="0.00024000000000000003" transform="matrix(1, 0, 0, 1, 0, 0)rotate(0)">
+
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round" stroke="#CCCCCC" stroke-width="0.048"/>
+
+<g id="SVGRepo_iconCarrier"> <path fill-rule="evenodd" clip-rule="evenodd" d="M7.08642 13.0691L5.384 11.7072C5.13517 12.4254 5 13.1967 5 13.9996C5 17.8656 8.13401 20.9996 12 20.9996C15.866 20.9996 19 17.8656 19 13.9996C19 13.1967 18.8648 12.4254 18.616 11.7072L16.9136 13.0691C16.9703 13.3706 17 13.6816 17 13.9996C17 16.761 14.7614 18.9996 12 18.9996C9.23858 18.9996 7 16.761 7 13.9996C7 13.6816 7.02968 13.3706 7.08642 13.0691Z" fill="#ffffff"/> <path d="M12 13L11.3753 13.7809L12 14.2806L12.6247 13.7809L12 13ZM13 4C13 3.44772 12.5523 3 12 3C11.4477 3 11 3.44771 11 4L13 4ZM6.37531 9.78087L11.3753 13.7809L12.6247 12.2191L7.6247 8.21913L6.37531 9.78087ZM12.6247 13.7809L17.6247 9.78087L16.3753 8.21913L11.3753 12.2191L12.6247 13.7809ZM13 13L13 4L11 4L11 13L13 13Z" fill="#ffffff"/> </g>
+
+</svg>

--- a/SimplyTransport/static/static/style.css
+++ b/SimplyTransport/static/static/style.css
@@ -34,11 +34,7 @@ body {
 }
 
 .bold {
-	font-weight: bold;
-}
-
-.italic {
-	font-style: italic;
+	font-weight: 700;
 }
 
 .t-big {
@@ -242,7 +238,7 @@ h3 {
 }
 
 .bold-highlight {
-	font-weight: bold;
+	font-weight: 700;
 }
 
 .color-late {
@@ -400,7 +396,7 @@ h3 {
 
 .word-highlight {
 	color: var(--font-color-highlight);
-	font-weight: bold;
+	font-weight: 700;
 }
 
 .table-search-top-text-pad {
@@ -450,7 +446,6 @@ h3 {
 }
 
 .stop-feature-header {
-	font-weight: 600;
 	font-size: 1.1rem;
 	border-bottom: 2px solid var(--font-color-highlight);
 	display: flex;

--- a/SimplyTransport/templates/base.html
+++ b/SimplyTransport/templates/base.html
@@ -17,12 +17,8 @@
         <link rel="manifest" href="/site.webmanifest">
         <link rel="stylesheet"
               href="/static/style.css?{{ request.app.openapi_config.version }}" />
-        <link rel="stylesheet"
-              href="/static/event.css?{{ request.app.openapi_config.version }}" />
-        <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,500;0,700;0,900;1,400;1,500;1,700;1,900&display=swap"
-              rel="stylesheet">
+        {% include "fonts.html" %}
         <script defer src="/static/htmx.2.0.4.js"></script>
         <script defer src="/static/5.0.2.lightweight-charts-standalone-production.js"></script>
         <script defer

--- a/SimplyTransport/templates/events/events_main.html
+++ b/SimplyTransport/templates/events/events_main.html
@@ -7,6 +7,8 @@
             src="https://unpkg.com/@highlightjs/cdn-assets@11.9.0/highlight.min.js"
             integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ=="
             crossorigin="anonymous"></script>
+    <link rel="stylesheet"
+          href="/static/event.css?{{ request.app.openapi_config.version }}">
     <div class="narrow-container">
         <h1>Events</h1>
         <p class="dense-text">Events are records of things that have happened in the system.</p>

--- a/SimplyTransport/templates/events/list_of_events.html
+++ b/SimplyTransport/templates/events/list_of_events.html
@@ -12,7 +12,7 @@
 /* Numbers */
 .hljs-number {
     color: var(--font-color-secondary);
-    font-weight: bold
+    font-weight: 700
 }
 
 /* Keys */

--- a/SimplyTransport/templates/fonts.html
+++ b/SimplyTransport/templates/fonts.html
@@ -1,0 +1,62 @@
+<style>
+/* latin-ext */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/roboto/v47/KFO7CnqEu92Fr1ME7kSn66aGLdTylUAMa3KUBGEe.woff2) format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/roboto/v47/KFO7CnqEu92Fr1ME7kSn66aGLdTylUAMa3yUBA.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 500;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/roboto/v47/KFO7CnqEu92Fr1ME7kSn66aGLdTylUAMa3KUBGEe.woff2) format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 500;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/roboto/v47/KFO7CnqEu92Fr1ME7kSn66aGLdTylUAMa3yUBA.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/roboto/v47/KFO7CnqEu92Fr1ME7kSn66aGLdTylUAMa3KUBGEe.woff2) format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  font-stretch: 100%;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/roboto/v47/KFO7CnqEu92Fr1ME7kSn66aGLdTylUAMa3yUBA.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+</style>

--- a/SimplyTransport/templates/realtime/trip.html
+++ b/SimplyTransport/templates/realtime/trip.html
@@ -3,6 +3,8 @@
     SimplyTransport - Trip {{ prime_schedule.trip.short_name }} on Route {{ prime_schedule.route.short_name }}
 {% endblock title %}
 {% block content %}
+    <link rel="stylesheet"
+          href="/static/delays.css?{{ request.app.openapi_config.version }}">
     <div class="narrow-container">
         <h1>Trip: {{ prime_schedule.trip.short_name }}</h1>
         <div class="flex-gap">
@@ -27,6 +29,7 @@
                             <th class="dense-text">Scheduled</th>
                             <th class="dense-text">Realtime</th>
                             <th class="dense-text">Delay</th>
+                            <th class="dense-text">Historical</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -57,6 +60,17 @@
                                 <td class="dense-text no-pointer">{{ rt.static_schedule.stop_time.arrival_time }}</td>
                                 <td class="dense-text no-pointer">{{ rt.real_arrival_time }}</td>
                                 <td class="dense-text no-pointer">{{ rt.delay }}</td>
+                                <td class="dense-text"
+                                    delay-stop-id="{{ rt.static_schedule.stop.id }}"
+                                    delay-route-code="{{ rt.static_schedule.route.short_name }}"
+                                    delay-scheduled-time="{{ rt.static_schedule.stop_time.arrival_time }}">
+                                    <img class="link-icon-table"
+                                         src="/static/load-me.svg"
+                                         alt="link-icon"
+                                         width="13"
+                                         height="13">
+                                    Load...
+                                </td>
                             </tr>
                         {% endfor %}
                     </tbody>
@@ -76,4 +90,5 @@
     </div>
     {% include "widgets/copy_to_clipboard.html" %}
     {% include "widgets/filter_table.html" %}
+    {% include "widgets/delays_specific.html" %}
 {% endblock content %}

--- a/SimplyTransport/templates/widgets/delays_specific.html
+++ b/SimplyTransport/templates/widgets/delays_specific.html
@@ -1,0 +1,156 @@
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Find all cells with delay attributes
+        const delayCells = document.querySelectorAll('td[delay-stop-id]');
+        
+        delayCells.forEach(function(cell) {
+            cell.style.cursor = 'pointer';  // Show clickable cursor
+            let hoverTimer = null;
+            let detailRow = null;
+            
+            async function fetchData() {
+                // Don't fetch if already loaded
+                if (cell.getAttribute('data-loaded') === 'true') return;
+                
+                const imgElement = cell.querySelector('img');
+                if (!imgElement) return;
+                
+                const stopId = cell.getAttribute('delay-stop-id');
+                const routeCode = cell.getAttribute('delay-route-code');
+                const scheduledTime = cell.getAttribute('delay-scheduled-time');
+                
+                try {
+                    // Show loading state
+                    imgElement.src = "/static/loader.svg";
+                    
+                    const response = await fetch(
+                        `/api/v1/delays/${stopId}/${routeCode}/${scheduledTime}/aggregated`
+                    );
+
+                    if (response.status === 404) {
+                            cell.innerHTML = `
+                            <span>No data</span>
+                        `;
+                        cell.setAttribute('data-loaded', 'true');
+                        return;
+                    }
+                    
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+                    
+                    const data = await response.json();
+                    const avgMinutes = (data.avg / 60).toFixed(1);
+                    
+                    // Update main cell with average and toggle button
+                    cell.innerHTML = `
+                        <span>${avgMinutes} min</span>
+                        <button class="delays-specific-toggle-button">▼</button>
+                    `;
+                    
+                    cell.setAttribute('data-loaded', 'true');
+                    
+                    // Create detail row content
+                    const detailContent = `
+                        <td colspan="6" class="delays-specific-stats-detail-cell dense-text">
+                            <div class="delays-specific-stats-grid" style="opacity: 0; transition: opacity 0.3s ease-out;">
+                            <div class="delays-specific-stats-row">
+                                    <span>Avg: ${avgMinutes} min</span>
+                                </div>
+                                <div class="delays-specific-stats-row">
+                                    <span>Min: ${(data.min / 60).toFixed(1)} min</span>
+                                </div>
+                                <div class="delays-specific-stats-row">
+                                    <span>Max: ${(data.max / 60).toFixed(1)} min</span>
+                                </div>
+                                <div class="delays-specific-stats-row">
+                                    <span>Std Dev: ${(data.standard_deviation / 60).toFixed(1)} min</span>
+                                </div>
+                                <div class="delays-specific-stats-row">
+                                    <span>P50: ${(data.p50 / 60).toFixed(1)} min</span>
+                                </div>
+                                <div class="delays-specific-stats-row">
+                                    <span>P75: ${(data.p75 / 60).toFixed(1)} min</span>
+                                </div>
+                                <div class="delays-specific-stats-row">
+                                    <span>P90: ${(data.p90 / 60).toFixed(1)} min</span>
+                                </div>
+                                <div class="delays-specific-stats-row">
+                                    <span>Samples: ${data.samples}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+                    `;
+                    
+                    // Add click handler for toggle button
+                    const toggleButton = cell.querySelector('.delays-specific-toggle-button');
+                    
+                    toggleButton.addEventListener('click', function(e) {
+                        e.stopPropagation();
+                        
+                        if (detailRow && detailRow.parentNode) {
+                            // Add transition for closing
+                            const detailCell = detailRow.querySelector('.delays-specific-stats-detail-cell');
+                            const gridContent = detailCell.querySelector('.delays-specific-stats-grid');
+                            
+                            // Fade out content first
+                            gridContent.style.opacity = '0';
+                            detailCell.classList.remove('expanded');
+                            
+                            // Remove after transition
+                            setTimeout(() => {
+                                detailRow.parentNode.removeChild(detailRow);
+                                detailRow = null;
+                            }, 200);
+                            
+                            toggleButton.textContent = '▼';
+                        } else {
+                            // Create and insert detail row
+                            const parentRow = cell.closest('tr');
+                            detailRow = document.createElement('tr');
+                            detailRow.innerHTML = detailContent;
+                            parentRow.insertAdjacentElement('afterend', detailRow);
+                            
+                            // Trigger transition after a small delay
+                            requestAnimationFrame(() => {
+                                const detailCell = detailRow.querySelector('.delays-specific-stats-detail-cell');
+                                detailCell.classList.add('expanded');
+                                
+                                // Fade in content after expansion starts
+                                setTimeout(() => {
+                                    const gridContent = detailCell.querySelector('.delays-specific-stats-grid');
+                                    gridContent.style.opacity = '1';
+                                }, 50);
+                            });
+                            
+                            toggleButton.textContent = '▲';
+                        }
+                    });
+                    
+                } catch (error) {
+                    console.error('Error fetching delays:', error);
+                    imgElement.src = "/static/load-me.svg";  // Reset to original icon
+                    cell.title = "Failed to load delay data. Click to try again.";
+                }
+            }
+            
+            // Click handler
+            cell.addEventListener('click', fetchData);
+            
+            // Hover handlers
+            cell.addEventListener('mouseenter', function() {
+                // Start a timer when mouse enters
+                hoverTimer = setTimeout(fetchData, 200);
+            });
+            
+            cell.addEventListener('mouseleave', function() {
+                // Cancel the timer if mouse leaves before fetch
+                if (hoverTimer) {
+                    clearTimeout(hoverTimer);
+                    hoverTimer = null;
+                }
+            });
+        });
+    });
+</script>

--- a/SimplyTransport/timescale/ts_stop_times/model.py
+++ b/SimplyTransport/timescale/ts_stop_times/model.py
@@ -26,24 +26,24 @@ class TS_StopTimeModel(BigIntBase):
 
 
 class TS_StopTime(BaseModel):
-    Timestamp: datetime
+    timestamp: datetime
     stop_id: str
     route_code: str
     scheduled_time: time
-    delay_in_seconds: int
+    delay_in_seconds: int = Field(exclude=True)
 
+    @computed_field(description="Delay in minutes (rounded to 1 decimal place)", return_type=float)
     @property
-    @computed_field
     def delay_in_minutes(self) -> float:
         return round(self.delay_in_seconds / 60, 1)
 
 
 class TS_StopTimeForGraph(BaseModel):
-    Timestamp: datetime
+    timestamp: datetime
     delay_in_seconds: int = Field(exclude=True)
 
+    @computed_field(description="Delay in minutes (rounded to 1 decimal place)", return_type=float)
     @property
-    @computed_field
     def delay_in_minutes(self) -> float:
         return round(self.delay_in_seconds / 60, 1)
 

--- a/SimplyTransport/timescale/ts_stop_times/repo.py
+++ b/SimplyTransport/timescale/ts_stop_times/repo.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .model import TS_StopTimeDelayAggregated, TS_StopTimeForGraph, TS_StopTimeModel
 
-MAXIMUM_LIMIT = 730
+MAXIMUM_LIMIT = 180
 MAXIMUM_TIMESTAMP = datetime.now() - timedelta(days=MAXIMUM_LIMIT)
 
 
@@ -186,7 +186,7 @@ class TSStopTimeRepository(SQLAlchemyAsyncRepository[TS_StopTimeModel]):  # type
         result = await self.session.execute(statement)
         rows = result.all()
 
-        return [TS_StopTimeForGraph(Timestamp=row[0], delay_in_seconds=row[1]) for row in rows]
+        return [TS_StopTimeForGraph(timestamp=row[0], delay_in_seconds=row[1]) for row in rows]
 
     async def delete_old_delays(self, cutoff_time: datetime) -> int:
         """


### PR DESCRIPTION
## Summary by Sourcery

This pull request introduces a new feature to display historical delay data for trips at specific stops. It also includes enhancements to the UI and reduces the maximum number of records fetched for delay data.

New Features:
- Adds a feature to display historical delay data for specific trips at stops, showing average, min, max, standard deviation, and percentile delays.

Enhancements:
- Improves the display of delay information on the trip details page by adding a column to show historical delay data.
- Reduces the maximum number of records fetched for delay data from 730 to 180.

Build:
- Bumps the application version to 0.9.0 to cache bust static CSS/JS files.