### PR TITLE
remove chained queries on landing page

### DIFF
--- a/SimplyTransport/controllers/events.py
+++ b/SimplyTransport/controllers/events.py
@@ -1,4 +1,5 @@
 import math
+from datetime import UTC, datetime
 from typing import Literal
 
 from advanced_alchemy import NotFoundError
@@ -62,13 +63,14 @@ class EventsController(Controller):
 
             try:
                 events, total = await event_repo.get_paginated_events_by_type_with_total(
-                    event_type=search_type, limit_offset=limit_offset, order=sort
+                    event_type=EventType(search_type), limit_offset=limit_offset, order=sort
                 )
             except NotFoundError:
                 events = []
                 total = 0
 
-        events = [event.add_pretty_created_at() for event in events]
+        current_time = datetime.now(UTC)
+        events = [event.add_pretty_created_at(current_time) for event in events]
 
         current_page = limit_offset.offset // limit_offset.limit + 1
         total_pages = math.ceil(total / limit_offset.limit)

--- a/SimplyTransport/controllers/root.py
+++ b/SimplyTransport/controllers/root.py
@@ -37,11 +37,11 @@ class RootController(Controller):
             ]
         )
 
-        gtfs_updated_event = events[EventType.GTFS_DATABASE_UPDATED]
-        realtime_updated_event = events[EventType.REALTIME_DATABASE_UPDATED]
-        vehicles_updated_event = events[EventType.REALTIME_VEHICLES_DATABASE_UPDATED]
-        stop_features_updated_event = events[EventType.STOP_FEATURES_DATABASE_UPDATED]
-        delays_recorded_event = events[EventType.RECORD_TS_STOP_TIMES]
+        gtfs_updated_event = events.get(EventType.GTFS_DATABASE_UPDATED)
+        realtime_updated_event = events.get(EventType.REALTIME_DATABASE_UPDATED)
+        vehicles_updated_event = events.get(EventType.REALTIME_VEHICLES_DATABASE_UPDATED)
+        stop_features_updated_event = events.get(EventType.STOP_FEATURES_DATABASE_UPDATED)
+        delays_recorded_event = events.get(EventType.RECORD_TS_STOP_TIMES)
 
         return Template(
             template_name="index.html",

--- a/SimplyTransport/controllers/root.py
+++ b/SimplyTransport/controllers/root.py
@@ -8,8 +8,6 @@ from ..domain.agency.repo import AgencyRepository, provide_agency_repo
 from ..domain.events.event_types import EventType
 from ..domain.events.repo import EventRepository, provide_event_repo
 from ..domain.maps.enums import StaticStopMapTypes
-from ..domain.maps.maps import Map
-from ..domain.services.map_service import MapService
 from ..lib.constants import APP_DIR, STATIC_DIR
 from ..lib.db.services import test_database_connections
 from ..lib.logging.logging import provide_logger
@@ -22,32 +20,28 @@ logger = provide_logger(__name__)
 
 
 class RootController(Controller):
-    dependencies = {
-        "event_repo": Provide(provide_event_repo),
-        "agency_repo": Provide(provide_agency_repo),
-        "map_service": Provide(MapService, sync_to_thread=False),
-        "map": Provide(Map, sync_to_thread=False),
-    }
+    dependencies = {"event_repo": Provide(provide_event_repo), "agency_repo": Provide(provide_agency_repo)}
 
     @get("/", cache=120)
     async def root(
         self,
         event_repo: EventRepository,
     ) -> Template:
-        gtfs_updated_event = await event_repo.get_single_pretty_event_by_type(EventType.GTFS_DATABASE_UPDATED)
-        realtime_updated_event = await event_repo.get_single_pretty_event_by_type(
-            EventType.REALTIME_DATABASE_UPDATED
-        )
-        vehicles_updated_event = await event_repo.get_single_pretty_event_by_type(
-            EventType.REALTIME_VEHICLES_DATABASE_UPDATED
-        )
-        stop_features_updated_event = await event_repo.get_single_pretty_event_by_type(
-            EventType.STOP_FEATURES_DATABASE_UPDATED
+        events = await event_repo.get_multiple_pretty_events_by_types(
+            [
+                EventType.GTFS_DATABASE_UPDATED,
+                EventType.REALTIME_DATABASE_UPDATED,
+                EventType.REALTIME_VEHICLES_DATABASE_UPDATED,
+                EventType.STOP_FEATURES_DATABASE_UPDATED,
+                EventType.RECORD_TS_STOP_TIMES,
+            ]
         )
 
-        delays_recorded_event = await event_repo.get_single_pretty_event_by_type(
-            EventType.RECORD_TS_STOP_TIMES
-        )
+        gtfs_updated_event = events[EventType.GTFS_DATABASE_UPDATED]
+        realtime_updated_event = events[EventType.REALTIME_DATABASE_UPDATED]
+        vehicles_updated_event = events[EventType.REALTIME_VEHICLES_DATABASE_UPDATED]
+        stop_features_updated_event = events[EventType.STOP_FEATURES_DATABASE_UPDATED]
+        delays_recorded_event = events[EventType.RECORD_TS_STOP_TIMES]
 
         return Template(
             template_name="index.html",

--- a/SimplyTransport/domain/events/model.py
+++ b/SimplyTransport/domain/events/model.py
@@ -36,12 +36,11 @@ class EventModel(BigIntAuditBase):
     def to_json(self, indent: int = 4) -> str:
         return json.dumps(self.to_dict(), cls=DateTimeEncoderForJson, indent=indent)
 
-    def add_pretty_created_at(self):
+    def add_pretty_created_at(self, current_time: datetime):
         """Adds a created_at_pretty to an event"""
-        now = datetime.now()
-        if self.created_at.date() == now.date():
+        if self.created_at.date() == current_time.date():
             self.created_at_pretty = "Today - " + self.created_at.strftime("%H:%M")
-        elif self.created_at.date() == (now - timedelta(days=1)).date():
+        elif self.created_at.date() == (current_time - timedelta(days=1)).date():
             self.created_at_pretty = "Yesterday - " + self.created_at.strftime("%H:%M")
         else:
             self.created_at_pretty = self.created_at.strftime("%d %b - %H:%M")

--- a/SimplyTransport/domain/events/repo.py
+++ b/SimplyTransport/domain/events/repo.py
@@ -40,7 +40,9 @@ class EventRepository(SQLAlchemyAsyncRepository[EventModel]):
         """Get paginated events by type with total."""
 
         results, total = await self.list_and_count(
-            EventModel.event_type == event_type, OrderBy(EventModel.created_at.__str__(), order), limit_offset
+            EventModel.event_type == event_type,
+            OrderBy(EventModel.created_at, order),
+            limit_offset,  # type: ignore
         )
 
         if total == 0:
@@ -93,7 +95,8 @@ class EventRepository(SQLAlchemyAsyncRepository[EventModel]):
         """Get paginated events with total."""
 
         results, total = await self.list_and_count(
-            OrderBy(EventModel.created_at.__str__(), order), limit_offset
+            OrderBy(EventModel.created_at, order),
+            limit_offset,  # type: ignore
         )
 
         if total == 0:
@@ -106,7 +109,7 @@ class EventRepository(SQLAlchemyAsyncRepository[EventModel]):
     ) -> list[EventModel]:
         """Get paginated events."""
 
-        results = await self.list(OrderBy(EventModel.created_at.__str__(), order), limit_offset)
+        results = await self.list(OrderBy(EventModel.created_at, order), limit_offset)  # type: ignore
 
         return results
 

--- a/SimplyTransport/lib/exception_handlers.py
+++ b/SimplyTransport/lib/exception_handlers.py
@@ -17,7 +17,7 @@ def check_if_website(request: Request) -> bool:
     Returns:
         bool: True if the request accepts HTML content, False otherwise.
     """
-    return "text/html" in request.headers.get("accept", "")
+    return "text/html" in request.headers.get("accept", "") or "true" in request.headers.get("Hx-Request", "")
 
 
 def handle_404(_: Request, exc: HTTPException) -> Response | Template:


### PR DESCRIPTION
## Summary by Sourcery

Refactors the landing page to retrieve multiple events with a single database query, improving efficiency. It also modifies the event repository to allow ordering by created_at.

Enhancements:
- Improves the efficiency of retrieving events for the landing page by using a single database query instead of multiple chained queries.
- Updates the event repository to allow ordering by created_at.