### PR TITLE
delay stats

### DIFF
--- a/SimplyTransport/app.py
+++ b/SimplyTransport/app.py
@@ -24,7 +24,7 @@ def create_app() -> Litestar:
     return Litestar(
         debug=settings.app.DEBUG,
         route_handlers=[create_views_router(), create_api_router(), create_static_router()],
-        on_startup=[db_services.create_database, logging_setup],
+        on_startup=[db_services.create_database_tables, logging_setup],
         on_shutdown=[logging_shutdown],
         plugins=[sqlalchemy_plugin, CLIPlugin(), open_telemetry_plugin],
         stores=StoreRegistry(default_factory=redis_store_factory),

--- a/SimplyTransport/cli.py
+++ b/SimplyTransport/cli.py
@@ -612,7 +612,7 @@ class CLIPlugin(CLIPluginProtocol):
                         db_session=session,
                         timescale_db_session=timescale_session,
                     )
-                await statistics_service.update_all_statistics()
+                    await statistics_service.update_all_statistics()
 
             redis_service = await provide_redis_service()
             await redis_service.delete_keys_by_pattern(

--- a/SimplyTransport/cli.py
+++ b/SimplyTransport/cli.py
@@ -374,13 +374,14 @@ class CLIPlugin(CLIPluginProtocol):
             console.print(f"\n[blue]Finished import in {round(finish - start, 2)} second(s)")
 
         @cli.command(name="create_tables", help="Creates the database tables")
-        def create_tables():
+        @make_sync
+        async def create_tables():
             """Creates the database tables"""
 
             console = Console()
             console.print("Creating database tables...")
 
-            db_services.create_database_sync()
+            await db_services.create_database_tables()
 
         @cli.command(name="importstopfeatures", help="Imports stop features into the database")
         @click.option("-dir", help="Override the directory containing the stop feature data to import")
@@ -461,7 +462,8 @@ class CLIPlugin(CLIPluginProtocol):
 
         @cli.command(name="recreate_indexes", help="Recreates the indexes on a given table")
         @click.option("-table", help="The table to recreate the indexes on")
-        def recreate_indexes(table: str | None = None):
+        @make_sync
+        async def recreate_indexes(table: str | None = None):
             """Recreates the indexes on a given table"""
 
             console = Console()
@@ -493,7 +495,7 @@ class CLIPlugin(CLIPluginProtocol):
 
             start = time.perf_counter()
 
-            db_services.recreate_indexes(table)
+            await db_services.recreate_indexes(table)
 
             finish = time.perf_counter()
             console.print(f"\n[blue]Finished recreating indexes in {round(finish - start, 2)} second(s)")

--- a/SimplyTransport/domain/database_statistics/statistic_type.py
+++ b/SimplyTransport/domain/database_statistics/statistic_type.py
@@ -13,3 +13,6 @@ class StatisticType(str, Enum):
 
     # Stop Features
     STOP_FEATURE_COUNTS = "stop_features.feature.counts"
+
+    # Delays
+    DELAY_RECORD_COUNTS = "delay.record.counts"

--- a/SimplyTransport/lib/cache_keys.py
+++ b/SimplyTransport/lib/cache_keys.py
@@ -69,6 +69,30 @@ class CacheKeys:
         ROUTES_BY_STOP_ID_DELETE_ALL_KEY_TEMPLATE = "*routes_by_stop_id:*"
         ROUTES_BY_STOP_ID_DELETE_KEY_TEMPLATE = "*routes_by_stop_id:{stop_id}"
 
+    class Statistics(StrEnum):
+        STATIC_STATS_KEY_TEMPLATE = "stats:static:most_recent"
+        OPERATOR_STATS_KEY_TEMPLATE = "stats:operators:most_recent"
+        STOP_FEATURES_STATS_KEY_TEMPLATE = "stats:stop_features:most_recent"
+        DELAYS_STATS_KEY_TEMPLATE = "stats:delays:most_recent"
+        STATISTICS_DELETE_ALL_KEY_TEMPLATE = "*stats:*"
+
+
+def simple_key_builder(template: StrEnum) -> Callable[[Request], str]:
+    """
+    Builds a simple cache key from a template without any parameters.
+
+    Args:
+        template (StrEnum): The template for the cache key.
+
+    Returns:
+        callable: A function that takes a request object and returns the cache key.
+    """
+
+    def _key_builder(request: Request) -> str:
+        return template.value
+
+    return _key_builder
+
 
 def key_builder_from_path(template: StrEnum, *args) -> Callable[[Request], str]:
     """

--- a/SimplyTransport/lib/db/services.py
+++ b/SimplyTransport/lib/db/services.py
@@ -9,7 +9,7 @@ from .database import async_engine, engine
 from .timescale_database import async_timescale_engine
 
 
-async def create_database() -> None:
+async def create_database_tables() -> None:
     """
     Creates the database tables.
 
@@ -30,29 +30,19 @@ async def create_database() -> None:
         )
         raise e
 
-
-def create_database_sync() -> None:
-    """
-    Creates the database tables synchronously.
-
-    This function creates all the tables defined in the SQLAlchemy models
-    using the metadata and the database connection from the current session.
-
-    Raises:
-        ConnectionRefusedError: If the database connection is refused.
-    """
     try:
-        UUIDBase.metadata.create_all(bind=engine)
+        async with async_timescale_engine.begin() as conn:
+            await conn.run_sync(UUIDBase.metadata.create_all)
     except ConnectionRefusedError as e:
         print(e)
         print(
-            f"\nDatabase connection refused. Please ensure the database "
-            f"is running and accessible.\nURL: {engine.url}\n"
+            f"\nTimescale database connection refused. Please ensure the database is "
+            f"running and accessible.\nURL: {async_timescale_engine.url}\n"
         )
         raise e
 
 
-def recreate_indexes(table_name: str | None = None):
+async def recreate_indexes(table_name: str | None = None):
     """Recreate all indexes
 
     Args:

--- a/SimplyTransport/templates/stats/delays_data.html
+++ b/SimplyTransport/templates/stats/delays_data.html
@@ -1,0 +1,35 @@
+<div class="inner-container">
+    <h3 class="h3-table">Delay Records</h3>
+    <table class="table-search table-sortable" aria-label="Delay Records">
+        <thead class="hoverable">
+            <tr>
+                <th class="dense-text">Name</th>
+                <th class="dense-text">Value</th>
+                <th class="dense-text" data-type="number">Percentage</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for stat in stats_with_percentages %}
+                <tr>
+                    <td class="dense-text no-pointer">{{ stat.key }}</td>
+                    <td class="dense-text no-pointer">{{ stat.value }}</td>
+                    <td class="dense-text no-pointer">{{ stat.percentage }}%</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+<script>
+document.querySelectorAll(".table-sortable th").forEach((headerCell) => {
+  headerCell.addEventListener("click", () => {
+    const tableElement = headerCell.parentElement.parentElement.parentElement;
+    const headerIndex = Array.prototype.indexOf.call(
+      headerCell.parentElement.children,
+      headerCell
+    );
+    const currentIsAscending = headerCell.classList.contains("th-sort-asc");
+
+    sortTableByColumn(tableElement, headerIndex, !currentIsAscending);
+  });
+});
+</script>

--- a/SimplyTransport/templates/stats/index.html
+++ b/SimplyTransport/templates/stats/index.html
@@ -44,6 +44,17 @@
                  hx-get="{{ url_for("stats.stop_features") }}"
                  hx-trigger="revealed"></div>
         </div>
+        <div class="inner-container">
+            <h2 class="no-top-margin">
+                Delay Statistics
+                <button class="toggle-visibility-button pagination-button">▼</button>
+            </h2>
+            <p class="dense-text">Statistics about the delay records.</p>
+            <div class="collapsible"
+                 style="max-height:0"
+                 hx-get="{{ url_for("stats.delays") }}"
+                 hx-trigger="revealed"></div>
+        </div>
     </div>
     {% include "widgets/toggle_visibility.html" %}
 {% endblock content %}


### PR DESCRIPTION
## Summary by Sourcery

Implement end-to-end support for delay record statistics by retrieving counts from TimescaleDB, persisting them in the statistics store, and exposing them via a cached web endpoint.

New Features:
- Introduce delay record statistics: fetch daily, weekly, and monthly counts from TimescaleDB and store them in the statistics database
- Expose a new "/delays/most-recent" endpoint with caching to display delay record statistics

Enhancements:
- Inject TSStopTimeRepository into StatisticsService and provider for TimescaleDB access
- Update CLI stats generation to use both main and TimescaleDB sessions and clear relevant cache keys after regeneration
- Add simple_key_builder utility and new cache key templates for standardized endpoint caching