### PR TITLE
Map styling and code cleanup

### DIFF
--- a/SimplyTransport/lib/settings.py
+++ b/SimplyTransport/lib/settings.py
@@ -10,7 +10,7 @@ class AppSettings(BaseSettings):
     NAME: str = "SimplyTransport"
     LOG_LEVEL: str = "DEBUG"
 
-    VERSION: str = "1.1.0"  # Version bumping will cache bust static css/js files
+    VERSION: str = "1.1.1"  # Version bumping will cache bust static css/js files
     SECRET_KEY: str = "secret"
     LITESTAR_APP: str = "SimplyTransport.app:create_app"
 

--- a/SimplyTransport/static/static/js/agency-map.js
+++ b/SimplyTransport/static/static/js/agency-map.js
@@ -4,34 +4,13 @@
 (function () {
     "use strict";
 
-    const OSM_RASTER_STYLE = {
-        version: 8,
-        sources: {
-            osm: {
-                type: "raster",
-                tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-                tileSize: 256,
-                attribution:
-                    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-            },
-        },
-        layers: [
-            {
-                id: "osm",
-                type: "raster",
-                source: "osm",
-                minzoom: 0,
-                maxzoom: 19,
-            },
-        ],
-    };
+    const {
+        createOsmRasterStyle,
+        addDefaultMapControls,
+        setLayerVisibility,
+    } = window.MapLibreMapShared;
 
-    function setLayerVisibility(map, id, visible) {
-        if (!map.getLayer(id)) {
-            return;
-        }
-        map.setLayoutProperty(id, "visibility", visible ? "visible" : "none");
-    }
+    const OSM_RASTER_STYLE = createOsmRasterStyle({ includeGlyphs: false });
 
     function buildLayerPanel(panel, payload, layerState, map) {
         const routes = payload.routes;
@@ -118,8 +97,7 @@
                     zoom: payload.zoom,
                 });
 
-                map.addControl(new maplibregl.NavigationControl(), "top-left");
-                map.addControl(new maplibregl.FullscreenControl(), "top-left");
+                addDefaultMapControls(map);
 
                 const layerState = {
                     routes: {},

--- a/SimplyTransport/static/static/js/maplibre-map-shared.js
+++ b/SimplyTransport/static/static/js/maplibre-map-shared.js
@@ -1,0 +1,108 @@
+/**
+ * Shared MapLibre map constants and helpers for stop-map, route-map, nearby-map,
+ * static-stop-map, and agency-map. Loaded before those scripts.
+ */
+(function (global) {
+	"use strict";
+
+	function getMaplibre() {
+		return global.maplibregl;
+	}
+
+	/**
+	 * OpenStreetMap raster base style. Symbol layers need glyphs; line-only maps can omit them.
+	 * @param {{ includeGlyphs?: boolean }} [opts]
+	 */
+	function createOsmRasterStyle(opts) {
+		const includeGlyphs = !opts || opts.includeGlyphs !== false;
+		const style = {
+			version: 8,
+			sources: {
+				osm: {
+					type: "raster",
+					tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+					tileSize: 256,
+					attribution:
+						'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+				},
+			},
+			layers: [
+				{
+					id: "osm",
+					type: "raster",
+					source: "osm",
+					minzoom: 0,
+					maxzoom: 19,
+				},
+			],
+		};
+		if (includeGlyphs) {
+			style.glyphs =
+				"https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf";
+		}
+		return style;
+	}
+
+	const LABEL_FONT = ["Open Sans Semibold"];
+
+	const MAP_LABEL_BADGE_PAINT = {
+		"text-color": "#ffffff",
+		"text-halo-color": "#313b46",
+		"text-halo-width": 3.5,
+		"text-halo-blur": 0.9,
+	};
+
+	const VEHICLE_LABEL_MIN_ZOOM = 14;
+	const STOP_LABEL_MIN_ZOOM = 15;
+	const VEHICLE_LABEL_TEXT_OFFSET = [0, 1.95];
+	const STOP_LABEL_TEXT_OFFSET = [0, 1.65];
+
+	function addDefaultMapControls(map) {
+		const m = getMaplibre();
+		if (!m) {
+			return;
+		}
+		map.addControl(new m.NavigationControl(), "top-left");
+		map.addControl(new m.FullscreenControl(), "top-left");
+	}
+
+	function setLayerVisibility(map, id, visible) {
+		if (!map.getLayer(id)) {
+			return;
+		}
+		map.setLayoutProperty(id, "visibility", visible ? "visible" : "none");
+	}
+
+	function startVehiclePulseAnimation(map, getPulseLayerIds) {
+		let raf = 0;
+		function tick() {
+			const wave = Math.sin((Date.now() / 2000) * Math.PI * 2) * 0.5 + 0.5;
+			const opacity = 0.12 + wave * 0.28;
+			const radius = 12 + wave * 10;
+			for (const lid of getPulseLayerIds()) {
+				if (map.getLayer(lid)) {
+					map.setPaintProperty(lid, "circle-opacity", opacity);
+					map.setPaintProperty(lid, "circle-radius", radius);
+				}
+			}
+			raf = requestAnimationFrame(tick);
+		}
+		raf = requestAnimationFrame(tick);
+		map.once("remove", () => {
+			cancelAnimationFrame(raf);
+		});
+	}
+
+	global.MapLibreMapShared = {
+		createOsmRasterStyle,
+		LABEL_FONT,
+		MAP_LABEL_BADGE_PAINT,
+		VEHICLE_LABEL_MIN_ZOOM,
+		STOP_LABEL_MIN_ZOOM,
+		VEHICLE_LABEL_TEXT_OFFSET,
+		STOP_LABEL_TEXT_OFFSET,
+		addDefaultMapControls,
+		setLayerVisibility,
+		startVehiclePulseAnimation,
+	};
+})(window);

--- a/SimplyTransport/static/static/js/nearby-map.js
+++ b/SimplyTransport/static/static/js/nearby-map.js
@@ -24,38 +24,16 @@
         };
     }
 
-    const STOP_LABEL_MIN_ZOOM = 15;
-    const LABEL_FONT = ["Open Sans Semibold"];
-    const MAP_LABEL_BADGE_PAINT = {
-        "text-color": "#ffffff",
-        "text-halo-color": "#313b46",
-        "text-halo-width": 3.5,
-        "text-halo-blur": 0.9,
-    };
-    const STOP_LABEL_TEXT_OFFSET = [0, 1.65];
+    const {
+        createOsmRasterStyle,
+        LABEL_FONT,
+        MAP_LABEL_BADGE_PAINT,
+        STOP_LABEL_MIN_ZOOM,
+        STOP_LABEL_TEXT_OFFSET,
+        addDefaultMapControls,
+    } = window.MapLibreMapShared;
 
-    const OSM_RASTER_STYLE = {
-        version: 8,
-        glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
-        sources: {
-            osm: {
-                type: "raster",
-                tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-                tileSize: 256,
-                attribution:
-                    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-            },
-        },
-        layers: [
-            {
-                id: "osm",
-                type: "raster",
-                source: "osm",
-                minzoom: 0,
-                maxzoom: 19,
-            },
-        ],
-    };
+    const OSM_RASTER_STYLE = createOsmRasterStyle();
 
     function initNearbyMap(latitude, longitude, containerId) {
         const container = document.getElementById(containerId);
@@ -91,8 +69,7 @@
                     zoom: payload.zoom,
                 });
 
-                map.addControl(new maplibregl.NavigationControl(), "top-left");
-                map.addControl(new maplibregl.FullscreenControl(), "top-left");
+                addDefaultMapControls(map);
 
                 const stopsGeojson = {
                     type: "FeatureCollection",

--- a/SimplyTransport/static/static/js/route-map.js
+++ b/SimplyTransport/static/static/js/route-map.js
@@ -5,66 +5,20 @@
 (function () {
     "use strict";
 
-    /** demotiles.maplibre.org fonts (same as MapLibre demo style; Bold is not available). */
-    const VEHICLE_LABEL_MIN_ZOOM = 14;
-    const STOP_LABEL_MIN_ZOOM = 15;
-    const LABEL_FONT = ["Open Sans Semibold"];
-    /** Matches --bg-color-bump-border; halo + white text ≈ dark rounded badge (no native text-background in MapLibre). */
-    const MAP_LABEL_BADGE_PAINT = {
-        "text-color": "#ffffff",
-        "text-halo-color": "#313b46",
-        "text-halo-width": 3.5,
-        "text-halo-blur": 0.9,
-    };
-    const VEHICLE_LABEL_TEXT_OFFSET = [0, 1.95];
-    const STOP_LABEL_TEXT_OFFSET = [0, 1.65];
+    const {
+        createOsmRasterStyle,
+        LABEL_FONT,
+        MAP_LABEL_BADGE_PAINT,
+        VEHICLE_LABEL_MIN_ZOOM,
+        STOP_LABEL_MIN_ZOOM,
+        VEHICLE_LABEL_TEXT_OFFSET,
+        STOP_LABEL_TEXT_OFFSET,
+        addDefaultMapControls,
+        setLayerVisibility,
+        startVehiclePulseAnimation,
+    } = window.MapLibreMapShared;
 
-    /**
-     * @param {object} map - maplibregl Map
-     * @param {() => string[]} getPulseLayerIds
-     */
-    function startVehiclePulseAnimation(map, getPulseLayerIds) {
-        let raf = 0;
-        function tick() {
-            const wave = Math.sin((Date.now() / 2000) * Math.PI * 2) * 0.5 + 0.5;
-            const opacity = 0.12 + wave * 0.28;
-            const radius = 12 + wave * 10;
-            for (const lid of getPulseLayerIds()) {
-                if (map.getLayer(lid)) {
-                    map.setPaintProperty(lid, "circle-opacity", opacity);
-                    map.setPaintProperty(lid, "circle-radius", radius);
-                }
-            }
-            raf = requestAnimationFrame(tick);
-        }
-        raf = requestAnimationFrame(tick);
-        map.once("remove", () => {
-            cancelAnimationFrame(raf);
-        });
-    }
-
-    const OSM_RASTER_STYLE = {
-        version: 8,
-        glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
-        sources: {
-            osm: {
-                type: "raster",
-                tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-                tileSize: 256,
-                attribution:
-                    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-            },
-        },
-        layers: [
-            {
-                id: "osm",
-                type: "raster",
-                source: "osm",
-                minzoom: 0,
-                maxzoom: 19,
-            },
-        ],
-    };
+    const OSM_RASTER_STYLE = createOsmRasterStyle();
 
     const LINE_ID = "route-line-main";
     const VEHICLE_PULSE_ID = "vehicle-pulse-main";
@@ -115,8 +69,7 @@
                     zoom: payload.zoom,
                 });
 
-                map.addControl(new maplibregl.NavigationControl(), "top-left");
-                map.addControl(new maplibregl.FullscreenControl(), "top-left");
+                addDefaultMapControls(map);
 
                 const r = payload.route;
                 const stopsGeojson = {
@@ -406,13 +359,6 @@
                 container.innerHTML =
                     '<p class="map-error">Map could not be loaded. Try again later.</p>';
             });
-    }
-
-    function setLayerVisibility(map, id, visible) {
-        if (!map.getLayer(id)) {
-            return;
-        }
-        map.setLayoutProperty(id, "visibility", visible ? "visible" : "none");
     }
 
     function buildRouteLayerPanel(panel, map, route, hasVehicles) {

--- a/SimplyTransport/static/static/js/static-stop-map.js
+++ b/SimplyTransport/static/static/js/static-stop-map.js
@@ -4,38 +4,16 @@
 (function () {
     "use strict";
 
-    const STOP_LABEL_MIN_ZOOM = 15;
-    const LABEL_FONT = ["Open Sans Semibold"];
-    const MAP_LABEL_BADGE_PAINT = {
-        "text-color": "#ffffff",
-        "text-halo-color": "#313b46",
-        "text-halo-width": 3.5,
-        "text-halo-blur": 0.9,
-    };
-    const STOP_LABEL_TEXT_OFFSET = [0, 1.65];
+    const {
+        createOsmRasterStyle,
+        LABEL_FONT,
+        MAP_LABEL_BADGE_PAINT,
+        STOP_LABEL_MIN_ZOOM,
+        STOP_LABEL_TEXT_OFFSET,
+        addDefaultMapControls,
+    } = window.MapLibreMapShared;
 
-    const OSM_RASTER_STYLE = {
-        version: 8,
-        glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
-        sources: {
-            osm: {
-                type: "raster",
-                tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-                tileSize: 256,
-                attribution:
-                    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-            },
-        },
-        layers: [
-            {
-                id: "osm",
-                type: "raster",
-                source: "osm",
-                minzoom: 0,
-                maxzoom: 19,
-            },
-        ],
-    };
+    const OSM_RASTER_STYLE = createOsmRasterStyle();
 
     function initStaticStopMap(mapType, containerId) {
         const container = document.getElementById(containerId);
@@ -68,8 +46,7 @@
                     zoom: payload.zoom,
                 });
 
-                map.addControl(new maplibregl.NavigationControl(), "top-left");
-                map.addControl(new maplibregl.FullscreenControl(), "top-left");
+                addDefaultMapControls(map);
 
                 const stopsGeojson = {
                     type: "FeatureCollection",

--- a/SimplyTransport/static/static/js/stop-detail-popup.js
+++ b/SimplyTransport/static/static/js/stop-detail-popup.js
@@ -16,6 +16,17 @@
 			.replace(/"/g, "&quot;");
 	}
 
+	/** @param {boolean | null | undefined} value */
+	function featureBoolToEmoji(value) {
+		if (value === true) {
+			return "✅";
+		}
+		if (value === false) {
+			return "❌";
+		}
+		return "—";
+	}
+
 	function fetchStopDetailed(stopId) {
 		return fetch(`/api/v1/stop/${encodeURIComponent(stopId)}/detailed`).then(
 			(r) => {
@@ -49,25 +60,23 @@
 		let featuresHtml = "";
 		if (detail.stop_features) {
 			const sf = detail.stop_features;
-			featuresHtml = `<p class="map-popup-block map-popup-muted">Wheelchair accessible: ${escapeHtml(sf.wheelchair_accessible)}<br>
-Bus Shelter: ${escapeHtml(sf.shelter_active)}<br>
-Realtime display: ${escapeHtml(sf.rtpi_active)}</p>`;
+			featuresHtml =
+				`<p class="map-popup-block map-popup-muted">Wheelchair accessible: ${featureBoolToEmoji(sf.wheelchair_accessible)}<br>` +
+				`Bus shelter: ${featureBoolToEmoji(sf.shelter_active)}<br>` +
+				`Realtime display: ${featureBoolToEmoji(sf.rtpi_active)}</p>`;
 		}
 
-		const lat = stop.lat != null ? stop.lat : "";
-		const lon = stop.lon != null ? stop.lon : "";
 		let streetBlock = "";
 		const streetUrl = detail.street_view_url || "";
 		if (streetUrl) {
-			streetBlock = `<a class="map-popup-link" href="${escapeHtml(streetUrl)}" target="_blank" rel="noopener noreferrer">Street view</a><br>`;
+			streetBlock =
+				`<p class="map-popup-block"><a class="map-popup-link" href="${escapeHtml(streetUrl)}" target="_blank" rel="noopener noreferrer">Street view</a></p>`;
 		}
 
 		return (
 			`<div class="map-popup-inner">` +
 			`<h4 class="map-popup-title"><a href="/realtime/stop/${escapeHtml(stop.id)}">${escapeHtml(title)}</a></h4>` +
-			`<p class="map-popup-block">` +
 			streetBlock +
-			`<span class="map-popup-muted">Lat: ${escapeHtml(lat)}<br>Lon: ${escapeHtml(lon)}</span></p>` +
 			featuresHtml +
 			`<p class="map-popup-block map-popup-routes-head"><strong>${routes.length} Routes</strong></p>` +
 			`<p class="map-popup-routes">${routesHtml}</p>` +

--- a/SimplyTransport/static/static/js/stop-map.js
+++ b/SimplyTransport/static/static/js/stop-map.js
@@ -5,70 +5,20 @@
 (function () {
 	"use strict";
 
-	/** Vehicle route labels appear first; stop codes require zooming in one step further. */
-	/** Match fonts bundled at demotiles.maplibre.org (see MapLibre demo style). */
-	const VEHICLE_LABEL_MIN_ZOOM = 14;
-	const STOP_LABEL_MIN_ZOOM = 15;
-	const LABEL_FONT = ["Open Sans Semibold"];
-	/** Matches --bg-color-bump-border in style.css. MapLibre has no text-background; thick blurred halo ≈ rounded pill. */
-	const MAP_LABEL_BADGE_PAINT = {
-		"text-color": "#ffffff",
-		"text-halo-color": "#313b46",
-		"text-halo-width": 3.5,
-		"text-halo-blur": 0.9,
-	};
-	/** Ems below anchor (larger Y = label further from the point). */
-	const VEHICLE_LABEL_TEXT_OFFSET = [0, 1.95];
-	const STOP_LABEL_TEXT_OFFSET = [0, 1.65];
+	const {
+		createOsmRasterStyle,
+		LABEL_FONT,
+		MAP_LABEL_BADGE_PAINT,
+		VEHICLE_LABEL_MIN_ZOOM,
+		STOP_LABEL_MIN_ZOOM,
+		VEHICLE_LABEL_TEXT_OFFSET,
+		STOP_LABEL_TEXT_OFFSET,
+		addDefaultMapControls,
+		setLayerVisibility,
+		startVehiclePulseAnimation,
+	} = window.MapLibreMapShared;
 
-	/**
-	 * Animate halo circles under vehicle markers (realtime “live” cue).
-	 * @param {object} map - maplibregl Map
-	 * @param {() => string[]} getPulseLayerIds
-	 */
-	function startVehiclePulseAnimation(map, getPulseLayerIds) {
-		let raf = 0;
-		function tick() {
-			const wave = Math.sin((Date.now() / 2000) * Math.PI * 2) * 0.5 + 0.5;
-			const opacity = 0.12 + wave * 0.28;
-			const radius = 12 + wave * 10;
-			for (const lid of getPulseLayerIds()) {
-				if (map.getLayer(lid)) {
-					map.setPaintProperty(lid, "circle-opacity", opacity);
-					map.setPaintProperty(lid, "circle-radius", radius);
-				}
-			}
-			raf = requestAnimationFrame(tick);
-		}
-		raf = requestAnimationFrame(tick);
-		map.once("remove", () => {
-			cancelAnimationFrame(raf);
-		});
-	}
-
-	/** OpenStreetMap raster tiles (same idea as classic OSM web maps). */
-	const OSM_RASTER_STYLE = {
-		version: 8,
-		glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
-		sources: {
-			osm: {
-				type: "raster",
-				tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-				tileSize: 256,
-				attribution:
-					'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-			},
-		},
-		layers: [
-			{
-				id: "osm",
-				type: "raster",
-				source: "osm",
-				minzoom: 0,
-				maxzoom: 19,
-			},
-		],
-	};
+	const OSM_RASTER_STYLE = createOsmRasterStyle();
 
 	function initStopMap(stopId, containerId) {
 		const container = document.getElementById(containerId);
@@ -109,8 +59,7 @@
 					zoom: payload.zoom,
 				});
 
-				map.addControl(new maplibregl.NavigationControl(), "top-left");
-				map.addControl(new maplibregl.FullscreenControl(), "top-left");
+				addDefaultMapControls(map);
 
 				const stopsGeojson = {
 					type: "FeatureCollection",
@@ -457,13 +406,6 @@
 				container.innerHTML =
 					'<p class="map-error">Map could not be loaded. Try again later.</p>';
 			});
-	}
-
-	function setLayerVisibility(map, id, visible) {
-		if (!map.getLayer(id)) {
-			return;
-		}
-		map.setLayoutProperty(id, "visibility", visible ? "visible" : "none");
 	}
 
 	function buildLayerPanel(panel, payload, layerState, map) {

--- a/SimplyTransport/static/static/style.css
+++ b/SimplyTransport/static/static/style.css
@@ -1077,8 +1077,11 @@
 	box-shadow: var(--shadow-md);
 	padding: 0;
 	font-family: "Roboto", sans-serif;
-	font-size: 0.875rem;
+	font-size: 0.8125rem;
 	line-height: 1.45;
+	/* Crisper text when MapLibre positions the popup with fractional-pixel transforms */
+	transform: translateZ(0);
+	backface-visibility: hidden;
 }
 
 .map-container--maplibre .maplibre-stop-popup .maplibregl-popup-content {
@@ -1145,7 +1148,7 @@
 
 .map-popup-inner .map-popup-title {
 	margin: 0 0 0.5rem;
-	font-size: 1rem;
+	font-size: 0.9375rem;
 	font-weight: 700;
 }
 

--- a/SimplyTransport/templates/base.html
+++ b/SimplyTransport/templates/base.html
@@ -19,6 +19,7 @@
               href="/static/style.css?{{ request.app.openapi_config.version }}" />
         <link rel="stylesheet" href="/static/maplibre-gl.5.21.1.css" />
         <script src="/static/js/maplibre-ready.js?{{ request.app.openapi_config.version }}"></script>
+        <script src="/static/js/maplibre-map-shared.js?{{ request.app.openapi_config.version }}"></script>
         <script defer src="/static/maplibre-gl.5.21.1.js"></script>
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         {% include "fonts.html" %}


### PR DESCRIPTION
## Summary by Sourcery

Centralize shared MapLibre configuration and helpers and refine map popup presentation.

New Features:
- Introduce a shared MapLibre helper module providing OSM raster style creation, label styling constants, default controls, and vehicle pulse animation for all map views.
- Display stop features in popups using status icons instead of raw boolean text values.

Enhancements:
- Refactor all map scripts to consume the shared MapLibre helper utilities instead of duplicating map style and control setup.
- Adjust stop popup typography and rendering hints for more compact, crisper display across MapLibre popups.
- Omit raw latitude/longitude text from stop detail popups to reduce clutter.

Build:
- Bump frontend asset version to 1.1.1 to cache-bust updated static JS/CSS assets.