### PR TITLE
upgrade to litestar 2.22

### DIFF
--- a/SimplyTransport/controllers/api/agency.py
+++ b/SimplyTransport/controllers/api/agency.py
@@ -2,6 +2,7 @@ from advanced_alchemy.exceptions import NotFoundError
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 
 from SimplyTransport.api_contract.agency import Agency, AgencyWithTotal
 
@@ -24,7 +25,7 @@ class AgencyController(Controller):
         return AgencyWithTotal(total=total, agencies=[Agency.model_validate(obj) for obj in result])
 
     @get("/{id:str}", summary="Agency by ID", raises=[NotFoundException])
-    async def get_agency_by_id(self, repo: AgencyRepository, id: str) -> Agency:
+    async def get_agency_by_id(self, repo: AgencyRepository, id: FromPath[str]) -> Agency:
         try:
             result = await repo.get(id)
         except NotFoundError as e:

--- a/SimplyTransport/controllers/api/calendar.py
+++ b/SimplyTransport/controllers/api/calendar.py
@@ -5,6 +5,7 @@ from advanced_alchemy.filters import OnBeforeAfter
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 
 from SimplyTransport.api_contract.calendar import Calendar, CalendarWithTotal
 
@@ -27,7 +28,7 @@ class CalendarController(Controller):
         return CalendarWithTotal(total=total, calendars=[Calendar.model_validate(obj) for obj in result])
 
     @get("/{id:str}", summary="Calendar by service ID", raises=[NotFoundException])
-    async def get_calendar_by_id(self, repo: CalendarRepository, id: str) -> Calendar:
+    async def get_calendar_by_id(self, repo: CalendarRepository, id: FromPath[str]) -> Calendar:
         try:
             result = await repo.get(id)
         except NotFoundError as e:
@@ -39,7 +40,9 @@ class CalendarController(Controller):
         summary="All active calendars on a given date",
         description="Date format = YYYY-MM-DD",
     )
-    async def get_active_calendars_on_date(self, repo: CalendarRepository, date: date) -> list[Calendar]:
+    async def get_active_calendars_on_date(
+        self, repo: CalendarRepository, date: FromPath[date]
+    ) -> list[Calendar]:
         start_date = datetime.combine(date, time.min)
         end_date = datetime.combine(date, time.max)
 

--- a/SimplyTransport/controllers/api/calendar_date.py
+++ b/SimplyTransport/controllers/api/calendar_date.py
@@ -4,6 +4,7 @@ from advanced_alchemy.filters import OnBeforeAfter
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 
 from SimplyTransport.api_contract.calendar_date import CalendarDate, CalendarDateWithTotal
 
@@ -32,7 +33,7 @@ class CalendarDateController(Controller):
 
     @get("/{service_id:str}", summary="CalendarDates by service ID", raises=[NotFoundException])
     async def get_calendar_dates_by_id(
-        self, repo: CalendarDateRepository, service_id: str
+        self, repo: CalendarDateRepository, service_id: FromPath[str]
     ) -> list[CalendarDate]:
         result = await repo.list(service_id=service_id)
         if result is None or len(result) == 0:
@@ -45,7 +46,7 @@ class CalendarDateController(Controller):
         description="Date format = YYYY-MM-DD",
     )
     async def get_active_calendar_dates_on_date(
-        self, repo: CalendarDateRepository, date: date
+        self, repo: CalendarDateRepository, date: FromPath[date]
     ) -> list[CalendarDate]:
         start_date = datetime.combine(date, time.min)
         end_date = datetime.combine(date, time.max)

--- a/SimplyTransport/controllers/api/delays.py
+++ b/SimplyTransport/controllers/api/delays.py
@@ -1,9 +1,7 @@
-from datetime import datetime, time
-
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException, ValidationException
-from litestar.params import Parameter
+from litestar.params import FromPath
 
 from SimplyTransport.api_contract.delays import (
     TS_StopTime,
@@ -12,6 +10,7 @@ from SimplyTransport.api_contract.delays import (
 )
 
 from ...lib.cache_keys import CacheKeys, key_builder_from_path
+from ...lib.parameters.time_query import EndDateTimeQuery, ScheduledTimePath, StartDateTimeQuery
 from ...lib.time_date_conversions import validate_time_range
 from ...timescale.ts_stop_times.repo import (
     MAXIMUM_LIMIT,
@@ -21,16 +20,6 @@ from ...timescale.ts_stop_times.repo import (
 )
 
 __all__ = ["DelaysController"]
-
-SCHEDULED_TIME_PARAM = Parameter(required=True, description="Format: HH:MM:SS")
-START_TIME_PARAM = Parameter(
-    required=False,
-    description="Use data from this time onwards. Format: 2023-10-13T21:34:23Z",
-)
-END_TIME_PARAM = Parameter(
-    required=False,
-    description="Use data up to this time. Format: 2023-10-13T21:34:23Z",
-)
 
 
 class DelaysController(Controller):
@@ -51,12 +40,12 @@ class DelaysController(Controller):
     )
     async def get_aggregated_delay_on_stop_on_route_on_time(
         self,
-        stop_id: str,
-        route_code: str,
+        stop_id: FromPath[str],
+        route_code: FromPath[str],
         repo: TSStopTimeRepository,
-        scheduled_time: time = SCHEDULED_TIME_PARAM,
-        start_time: datetime | None = START_TIME_PARAM,
-        end_time: datetime | None = END_TIME_PARAM,
+        scheduled_time: ScheduledTimePath,
+        start_time: StartDateTimeQuery = None,
+        end_time: EndDateTimeQuery = None,
     ) -> TS_StopTimeDelayAggregated:
         validate_time_range(start_time, end_time)
         result = await repo.get_aggregated_delay_on_stop_on_route_on_time(
@@ -83,12 +72,12 @@ class DelaysController(Controller):
     )
     async def get_delay_on_stop_on_route_on_time(
         self,
-        stop_id: str,
-        route_code: str,
+        stop_id: FromPath[str],
+        route_code: FromPath[str],
         repo: TSStopTimeRepository,
-        scheduled_time: time = SCHEDULED_TIME_PARAM,
-        start_time: datetime | None = START_TIME_PARAM,
-        end_time: datetime | None = END_TIME_PARAM,
+        scheduled_time: ScheduledTimePath,
+        start_time: StartDateTimeQuery = None,
+        end_time: EndDateTimeQuery = None,
     ) -> list[TS_StopTime]:
         if start_time and end_time and start_time > end_time:
             raise ValidationException(
@@ -117,12 +106,12 @@ class DelaysController(Controller):
     )
     async def get_truncated_delay_on_stop_on_route_on_time(
         self,
-        stop_id: str,
-        route_code: str,
+        stop_id: FromPath[str],
+        route_code: FromPath[str],
         repo: TSStopTimeRepository,
-        scheduled_time: time = SCHEDULED_TIME_PARAM,
-        start_time: datetime | None = START_TIME_PARAM,
-        end_time: datetime | None = END_TIME_PARAM,
+        scheduled_time: ScheduledTimePath,
+        start_time: StartDateTimeQuery = None,
+        end_time: EndDateTimeQuery = None,
     ) -> list[TS_StopTimeForGraph]:
         validate_time_range(start_time, end_time)
         result = await repo.get_truncated_delay_on_stop_on_route_on_time(
@@ -144,10 +133,10 @@ class DelaysController(Controller):
     )
     async def get_aggregated_delay_on_route(
         self,
-        route_code: str,
+        route_code: FromPath[str],
         repo: TSStopTimeRepository,
-        start_time: datetime | None = START_TIME_PARAM,
-        end_time: datetime | None = END_TIME_PARAM,
+        start_time: StartDateTimeQuery = None,
+        end_time: EndDateTimeQuery = None,
     ) -> TS_StopTimeDelayAggregated:
         validate_time_range(start_time, end_time)
         result = await repo.get_aggregated_delay_on_stop_on_route_on_time(

--- a/SimplyTransport/controllers/api/events.py
+++ b/SimplyTransport/controllers/api/events.py
@@ -1,10 +1,10 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from advanced_alchemy.filters import LimitOffset
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
-from litestar.params import Parameter
+from litestar.params import FromPath, QueryParameter
 
 from SimplyTransport.api_contract.events import Event, EventsWithTotal
 from SimplyTransport.domain.events.event_types import EventType
@@ -26,9 +26,10 @@ class EventsController(Controller):
         self,
         repo: EventRepository,
         limit_offset: LimitOffset,
-        order: Literal["desc", "asc"] = Parameter(
-            required=False, description="Order by descending or ascending", default="desc"
-        ),
+        order: Annotated[
+            Literal["desc", "asc"],
+            QueryParameter(description="Order by descending or ascending"),
+        ] = "desc",
     ) -> EventsWithTotal:
         result, total = await repo.get_paginated_events_with_total(limit_offset, order)
 
@@ -45,11 +46,12 @@ class EventsController(Controller):
     async def get_events_by_type(
         self,
         repo: EventRepository,
-        type: EventType,
+        type: FromPath[EventType],
         limit_offset: LimitOffset,
-        order: Literal["desc", "asc"] = Parameter(
-            required=False, description="Order by descending or ascending", default="desc"
-        ),
+        order: Annotated[
+            Literal["desc", "asc"],
+            QueryParameter(description="Order by descending or ascending"),
+        ] = "desc",
     ) -> EventsWithTotal:
         result, total = await repo.get_paginated_events_by_type_with_total(type, limit_offset, order)
 
@@ -66,7 +68,7 @@ class EventsController(Controller):
     async def get_most_recent_event_by_type(
         self,
         repo: EventRepository,
-        type: EventType,
+        type: FromPath[EventType],
     ) -> Event:
         result = await repo.get_most_recent_event_by_type(type)
 

--- a/SimplyTransport/controllers/api/map.py
+++ b/SimplyTransport/controllers/api/map.py
@@ -1,8 +1,10 @@
+from typing import Annotated
+
 from advanced_alchemy.exceptions import NotFoundError
 from litestar import Controller, MediaType, Request, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException, ValidationException
-from litestar.params import Parameter
+from litestar.params import FromPath, QueryParameter
 
 from SimplyTransport.api_contract.map_payloads import (
     AgencyRoutesMapPayload,
@@ -22,7 +24,7 @@ _MAP_JSON_VEHICLE_TTL_S = 120
 
 
 def _nearby_map_cache_key_builder(request: Request) -> str:
-    """Match Parameter default for radius_meters when the query omits it."""
+    """Match QueryParameter default for radius_meters when the query omits it."""
     radius = request.query_params.get("radius_meters")
     if radius is None:
         radius = "1200"
@@ -52,15 +54,17 @@ class MapController(Controller):
     async def nearby_map_data(
         self,
         map_service: MapService,
-        latitude: float = Parameter(query="latitude", required=True, description="Latitude"),
-        longitude: float = Parameter(query="longitude", required=True, description="Longitude"),
-        radius_meters: int = Parameter(
-            query="radius_meters",
-            default=1200,
-            ge=1,
-            le=1500,
-            description="Search radius in meters (1–1500). Defaults to 1200.",
-        ),
+        latitude: Annotated[float, QueryParameter(name="latitude", description="Latitude")],
+        longitude: Annotated[float, QueryParameter(name="longitude", description="Longitude")],
+        radius_meters: Annotated[
+            int,
+            QueryParameter(
+                name="radius_meters",
+                ge=1,
+                le=1500,
+                description="Search radius in meters (1–1500). Defaults to 1200.",
+            ),
+        ] = 1200,
     ) -> NearbyMapPayload:
         return await map_service.build_nearby_map_payload(latitude, longitude, radius_meters)
 
@@ -76,7 +80,7 @@ class MapController(Controller):
         ),
     )
     async def static_stops_map_data(
-        self, map_type: StaticStopMapTypes, map_service: MapService
+        self, map_type: FromPath[StaticStopMapTypes], map_service: MapService
     ) -> StaticStopsMapPayload:
         return await map_service.build_static_stop_map_payload(map_type)
 
@@ -89,7 +93,7 @@ class MapController(Controller):
         cache=_MAP_JSON_VEHICLE_TTL_S,
         cache_key_builder=key_builder_from_path(CacheKeys.StopMaps.STOP_MAP_KEY_TEMPLATE, "stop_id"),
     )
-    async def stop_map_data(self, stop_id: str, map_service: MapService) -> StopMapPayload:
+    async def stop_map_data(self, stop_id: FromPath[str], map_service: MapService) -> StopMapPayload:
         try:
             payload = await map_service.build_stop_map_payload(stop_id)
         except NotFoundError as e:
@@ -111,7 +115,9 @@ class MapController(Controller):
             CacheKeys.RouteMaps.ROUTE_MAP_KEY_TEMPLATE, "route_id", "direction"
         ),
     )
-    async def route_map_data(self, route_id: str, direction: int, map_service: MapService) -> RouteMapPayload:
+    async def route_map_data(
+        self, route_id: FromPath[str], direction: FromPath[int], map_service: MapService
+    ) -> RouteMapPayload:
         try:
             return await map_service.build_route_map_payload(route_id, direction)
         except NotFoundError as e:
@@ -130,7 +136,9 @@ class MapController(Controller):
             CacheKeys.StaticMaps.STATIC_MAP_AGENCY_ROUTE_KEY_TEMPLATE, "agency_id"
         ),
     )
-    async def agency_routes_map_data(self, agency_id: str, map_service: MapService) -> AgencyRoutesMapPayload:
+    async def agency_routes_map_data(
+        self, agency_id: FromPath[str], map_service: MapService
+    ) -> AgencyRoutesMapPayload:
         try:
             return await map_service.build_agency_routes_map_payload(agency_id)
         except ValueError as e:

--- a/SimplyTransport/controllers/api/realtime.py
+++ b/SimplyTransport/controllers/api/realtime.py
@@ -1,9 +1,9 @@
-from datetime import datetime, time, timedelta
+from datetime import datetime, timedelta
 
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import ValidationException
-from litestar.params import Parameter
+from litestar.params import FromPath
 
 from SimplyTransport.api_contract.realtime_schedule import RealTimeSchedule
 
@@ -16,17 +16,10 @@ from ...domain.services.schedule_service import (
     ScheduleService,
     provide_schedule_service,
 )
+from ...lib.parameters.time_query import DayQuery, EndTimeQuery, StartTimeQuery
 from ...lib.time_date_conversions import return_time_difference
 
 __all__ = ["RealtimeController"]
-
-START_TIME_PARAM = Parameter(
-    required=False, description="Start time, defaults to 10 minutes ago\n\nExample: 10:00:00"
-)
-END_TIME_PARAM = Parameter(
-    required=False, description="End time, defaults to 60 minutes from now\n\nExample: 11:00:00"
-)
-DAY_PARAM = Parameter(required=False, description="Day of week, defaults to today")
 
 
 class RealtimeController(Controller):
@@ -40,10 +33,10 @@ class RealtimeController(Controller):
         self,
         schedule_service: ScheduleService,
         realtime_service: RealTimeService,
-        stop_id: str,
-        start_time: time | None = START_TIME_PARAM,
-        end_time: time | None = END_TIME_PARAM,
-        day: DayOfWeek | None = DAY_PARAM,
+        stop_id: FromPath[str],
+        start_time: StartTimeQuery = None,
+        end_time: EndTimeQuery = None,
+        day: DayQuery = None,
     ) -> list[RealTimeSchedule]:
         """Returns a list of realtime schedules for the given stop_id"""
 

--- a/SimplyTransport/controllers/api/route.py
+++ b/SimplyTransport/controllers/api/route.py
@@ -1,8 +1,10 @@
+from typing import Annotated
+
 from advanced_alchemy.exceptions import NotFoundError
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
-from litestar.params import Parameter
+from litestar.params import FromPath, QueryParameter
 
 from SimplyTransport.api_contract.route import Route, RouteWithTotal
 
@@ -25,9 +27,10 @@ class RouteController(Controller):
     async def get_all_routes(
         self,
         repo: RouteRepository,
-        agency_id: str | None = Parameter(
-            query="agencyId", required=False, description="Optional: Agency ID to filter by"
-        ),
+        agency_id: Annotated[
+            str | None,
+            QueryParameter(name="agencyId", description="Optional: Agency ID to filter by"),
+        ] = None,
     ) -> list[Route]:
         if agency_id:
             result = await repo.list(agency_id=agency_id)
@@ -46,9 +49,10 @@ class RouteController(Controller):
     async def get_all_routes_and_count(
         self,
         repo: RouteRepository,
-        agency_id: str | None = Parameter(
-            query="agencyId", required=False, description="Optional: Agency ID to filter by"
-        ),
+        agency_id: Annotated[
+            str | None,
+            QueryParameter(name="agencyId", description="Optional: Agency ID to filter by"),
+        ] = None,
     ) -> RouteWithTotal:
         if agency_id:
             result, total = await repo.list_and_count(agency_id=agency_id)
@@ -59,7 +63,7 @@ class RouteController(Controller):
         return RouteWithTotal(total=total, routes=[Route.model_validate(obj) for obj in result])
 
     @get("/{id:str}", summary="Route by ID", raises=[NotFoundException])
-    async def get_route_by_id(self, repo: RouteRepository, id: str) -> Route:
+    async def get_route_by_id(self, repo: RouteRepository, id: FromPath[str]) -> Route:
         try:
             result = await repo.get(id)
         except NotFoundError as e:

--- a/SimplyTransport/controllers/api/schedule.py
+++ b/SimplyTransport/controllers/api/schedule.py
@@ -1,9 +1,9 @@
-from datetime import datetime, time, timedelta
+from datetime import datetime, timedelta
 
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import ValidationException
-from litestar.params import Parameter
+from litestar.params import FromPath
 
 from SimplyTransport.api_contract.schedule import StaticSchedule
 
@@ -12,17 +12,10 @@ from ...domain.services.schedule_service import (
     ScheduleService,
     provide_schedule_service,
 )
+from ...lib.parameters.time_query import DayQuery, EndTimeQuery, StartTimeQuery
 from ...lib.time_date_conversions import return_time_difference
 
 __all__ = ["ScheduleController"]
-
-START_TIME_PARAM = Parameter(
-    required=False, description="Start time, defaults to 10 minutes ago\n\nExample: 10:00:00"
-)
-END_TIME_PARAM = Parameter(
-    required=False, description="End time, defaults to 60 minutes from now\n\nExample: 11:00:00"
-)
-DAY_PARAM = Parameter(required=False, description="Day of week, defaults to today")
 
 
 class ScheduleController(Controller):
@@ -34,10 +27,10 @@ class ScheduleController(Controller):
     async def get_schedule_by_stop_id(
         self,
         schedule_service: ScheduleService,
-        stop_id: str,
-        start_time: time | None = START_TIME_PARAM,
-        end_time: time | None = END_TIME_PARAM,
-        day: DayOfWeek | None = DAY_PARAM,
+        stop_id: FromPath[str],
+        start_time: StartTimeQuery = None,
+        end_time: EndTimeQuery = None,
+        day: DayQuery = None,
     ) -> list[StaticSchedule]:
         """Returns a list of schedules for the given stop_id"""
 

--- a/SimplyTransport/controllers/api/shape.py
+++ b/SimplyTransport/controllers/api/shape.py
@@ -3,6 +3,7 @@ from typing import Any
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 
 from SimplyTransport.api_contract.shape import Shape
 
@@ -20,7 +21,7 @@ class ShapeController(Controller):
 
     @get("/{shape_id:str}", summary="List of Shapes by shape Id", raises=[NotFoundException])
     async def get_shape_by_shape_id(
-        self, repo: ShapeRepository, shape_id: str, order_by_shape: Any
+        self, repo: ShapeRepository, shape_id: FromPath[str], order_by_shape: Any
     ) -> list[Shape]:
         result = await repo.list(order_by_shape, shape_id=shape_id)
         if not result or len(result) == 0:

--- a/SimplyTransport/controllers/api/statistics.py
+++ b/SimplyTransport/controllers/api/statistics.py
@@ -3,6 +3,7 @@ import datetime
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 
 from SimplyTransport.api_contract.statistics import DatabaseStatistic
 from SimplyTransport.domain.database_statistics.statistic_type import StatisticType
@@ -21,7 +22,7 @@ class StatisticsController(Controller):
         raises=[NotFoundException],
     )
     async def get_statistics_most_recent(
-        self, repo: DatabaseStatisticRepository, key: StatisticType
+        self, repo: DatabaseStatisticRepository, key: FromPath[StatisticType]
     ) -> list[DatabaseStatistic]:
         result = await repo.get_statistics_most_recent_by_type(key)
 
@@ -37,7 +38,7 @@ class StatisticsController(Controller):
         raises=[NotFoundException],
     )
     async def get_statistics_by_day(
-        self, repo: DatabaseStatisticRepository, key: StatisticType, date: datetime.date
+        self, repo: DatabaseStatisticRepository, key: FromPath[StatisticType], date: FromPath[datetime.date]
     ) -> list[DatabaseStatistic]:
         result = await repo.get_statistics_by_type_and_date(key, date)
 

--- a/SimplyTransport/controllers/api/stop.py
+++ b/SimplyTransport/controllers/api/stop.py
@@ -1,10 +1,12 @@
+from typing import Annotated
+
 from advanced_alchemy.exceptions import NotFoundError
 from advanced_alchemy.filters import LimitOffset
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
 from litestar.pagination import OffsetPagination  # type: ignore
-from litestar.params import Parameter
+from litestar.params import FromPath, QueryParameter
 
 from SimplyTransport.api_contract.stop import Stop, StopDetailed
 from SimplyTransport.lib.cache_keys import CacheKeys, key_builder_from_path
@@ -33,7 +35,7 @@ class StopController(Controller):
         cache_key_builder=key_builder_from_path(CacheKeys.StopApi.DETAILED_KEY_TEMPLATE, "id"),
     )
     async def get_stop_detailed_by_id(
-        self, repo: StopRepository, route_repo: RouteRepository, id: str
+        self, repo: StopRepository, route_repo: RouteRepository, id: FromPath[str]
     ) -> StopDetailed:
         try:
             return await assemble_stop_detailed(repo, route_repo, id)
@@ -41,7 +43,7 @@ class StopController(Controller):
             raise NotFoundException(detail=f"Stop not found with id {id}") from e
 
     @get("/{id:str}", summary="Stop by ID", raises=[NotFoundException])
-    async def get_stop_by_id(self, repo: StopRepository, id: str) -> Stop:
+    async def get_stop_by_id(self, repo: StopRepository, id: FromPath[str]) -> Stop:
         try:
             result = await repo.get(id)
         except NotFoundError as e:
@@ -49,7 +51,7 @@ class StopController(Controller):
         return Stop.model_validate(result)
 
     @get("/code/{code:str}", summary="Stop by code", raises=[NotFoundException])
-    async def get_stop_by_code(self, repo: StopRepository, code: str) -> Stop:
+    async def get_stop_by_code(self, repo: StopRepository, code: FromPath[str]) -> Stop:
         try:
             result = await repo.get_by_code(code)
         except NotFoundError as e:
@@ -66,9 +68,10 @@ class StopController(Controller):
         self,
         repo: StopRepository,
         limit_offset: LimitOffset,
-        search: str = Parameter(
-            query="search", required=True, description="Search string to search by name or code"
-        ),
+        search: Annotated[
+            str,
+            QueryParameter(name="search", description="Search string to search by name or code"),
+        ],
     ) -> OffsetPagination[Stop]:
         try:
             results, total = await repo.list_by_name_or_code(search=search, limit_offset=limit_offset)

--- a/SimplyTransport/controllers/api/stoptime.py
+++ b/SimplyTransport/controllers/api/stoptime.py
@@ -1,6 +1,7 @@
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 
 from SimplyTransport.api_contract.stop_time import StopTime
 
@@ -13,14 +14,18 @@ class StopTimeController(Controller):
     dependencies = {"repo": Provide(provide_stop_time_repo)}
 
     @get("/trip/{trip_id:str}", summary="StopTimes by trip ID", raises=[NotFoundException])
-    async def get_stop_time_by_trip_id(self, repo: StopTimeRepository, trip_id: str) -> list[StopTime]:
+    async def get_stop_time_by_trip_id(
+        self, repo: StopTimeRepository, trip_id: FromPath[str]
+    ) -> list[StopTime]:
         results = await repo.list(trip_id=trip_id)
         if results is None or len(results) == 0:
             raise NotFoundException(detail=f"StopTimes not found for trip id {id}")
         return [StopTime.model_validate(obj) for obj in results]
 
     @get("/stop/{stop_id:str}", summary="StopTimes by stop ID", raises=[NotFoundException])
-    async def get_stop_time_by_stop_id(self, repo: StopTimeRepository, stop_id: str) -> list[StopTime]:
+    async def get_stop_time_by_stop_id(
+        self, repo: StopTimeRepository, stop_id: FromPath[str]
+    ) -> list[StopTime]:
         results = await repo.list(stop_id=stop_id)
         if results is None or len(results) == 0:
             raise NotFoundException(detail=f"StopTimes not found for stop id {id}")

--- a/SimplyTransport/controllers/api/trip.py
+++ b/SimplyTransport/controllers/api/trip.py
@@ -2,6 +2,7 @@ from advanced_alchemy.exceptions import NotFoundError
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 
 from SimplyTransport.api_contract.trip import Trip, TripsWithTotal
 
@@ -14,7 +15,7 @@ class TripController(Controller):
     dependencies = {"repo": Provide(provide_trip_repo)}
 
     @get("/{id:str}", summary="Trip by ID", raises=[NotFoundException])
-    async def get_trip_by_id(self, repo: TripRepository, id: str) -> Trip:
+    async def get_trip_by_id(self, repo: TripRepository, id: FromPath[str]) -> Trip:
         try:
             result = await repo.get(id)
         except NotFoundError as e:
@@ -26,7 +27,7 @@ class TripController(Controller):
         summary="All trips by route id",
         raises=[NotFoundException],
     )
-    async def get_all_trips_by_route_id(self, repo: TripRepository, route_id: str) -> list[Trip]:
+    async def get_all_trips_by_route_id(self, repo: TripRepository, route_id: FromPath[str]) -> list[Trip]:
         try:
             result = await repo.list(route_id=route_id)
         except NotFoundError as e:
@@ -39,7 +40,7 @@ class TripController(Controller):
         raises=[NotFoundException],
     )
     async def get_all_trips_by_route_id_and_count(
-        self, repo: TripRepository, route_id: str
+        self, repo: TripRepository, route_id: FromPath[str]
     ) -> TripsWithTotal:
         try:
             result, total = await repo.list_and_count(route_id=route_id)

--- a/SimplyTransport/controllers/delays.py
+++ b/SimplyTransport/controllers/delays.py
@@ -1,5 +1,6 @@
 from litestar import Controller, get
 from litestar.di import Provide
+from litestar.params import FromPath
 from litestar.response import Template
 
 from SimplyTransport.lib.cache_keys import CacheKeys, key_builder_from_path
@@ -22,7 +23,7 @@ class DelaysController(Controller):
     )
     async def delays_route(
         self,
-        route_code: str,
+        route_code: FromPath[str],
         repo: TSStopTimeRepository,
     ) -> Template:
         result = await repo.get_aggregated_delay_on_stop_on_route_on_time(route_code=route_code)

--- a/SimplyTransport/controllers/events.py
+++ b/SimplyTransport/controllers/events.py
@@ -1,13 +1,13 @@
 import math
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Annotated, Literal
 
 from advanced_alchemy.exceptions import NotFoundError
 from advanced_alchemy.filters import LimitOffset
 from litestar import Controller, get
 from litestar.di import Provide
 from litestar.exceptions import ValidationException
-from litestar.params import Parameter
+from litestar.params import QueryParameter
 from litestar.response import Template
 
 from ..domain.events.event_types import EventType
@@ -38,15 +38,17 @@ class EventsController(Controller):
         self,
         event_repo: EventRepository,
         limit_offset: LimitOffset,
-        search_type: str | None = Parameter(
-            query="search_type", required=False, description="Search events by type"
-        ),
-        sort: Literal["asc", "desc"] = Parameter(
-            query="sort",
-            required=False,
-            description="Sort events ascending or descending by creation time",
-            default="desc",
-        ),
+        search_type: Annotated[
+            str | None,
+            QueryParameter(name="search_type", description="Search events by type"),
+        ] = None,
+        sort: Annotated[
+            Literal["asc", "desc"],
+            QueryParameter(
+                name="sort",
+                description="Sort events ascending or descending by creation time",
+            ),
+        ] = "desc",
     ) -> Template:
         if search_type is None or search_type == ALL_EVENTS:
             search_type = ALL_EVENTS

--- a/SimplyTransport/controllers/maps.py
+++ b/SimplyTransport/controllers/maps.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from advanced_alchemy.exceptions import NotFoundError
 from litestar import Controller, get
 from litestar.di import Provide
+from litestar.params import FromPath
 from litestar.response import Template
 
 from ..domain.agency.repo import AgencyRepository, provide_agency_repo
@@ -22,7 +23,7 @@ class MapsController(Controller):
     }
 
     @get("/agency/route/{agency_id:str}")
-    async def agency_maps(self, agency_repo: AgencyRepository, agency_id: str) -> Template:
+    async def agency_maps(self, agency_repo: AgencyRepository, agency_id: FromPath[str]) -> Template:
         if agency_id != "All":
             try:
                 agency = await agency_repo.get(agency_id)
@@ -40,11 +41,11 @@ class MapsController(Controller):
         return Template("maps/agency_route.html", context={"agency": agency})
 
     @get("/static/agency/route/{agency_id:str}")
-    async def static_agency_route_map(self, agency_id: str) -> Template:
+    async def static_agency_route_map(self, agency_id: FromPath[str]) -> Template:
         return Template("maps/static/embed_agency_route.html", context={"agency_id": agency_id})
 
     @get("/stop/{map_type:str}")
-    async def stop_maps(self, map_type: str) -> Template:
+    async def stop_maps(self, map_type: FromPath[str]) -> Template:
         try:
             StaticStopMapTypes(map_type)
         except ValueError:
@@ -57,5 +58,5 @@ class MapsController(Controller):
         return Template("maps/stop.html", context={"map_type": map_type})
 
     @get("/static/stop/{map_type:str}")
-    async def static_stop_map(self, map_type: str) -> Template:
+    async def static_stop_map(self, map_type: FromPath[str]) -> Template:
         return Template("maps/static/embed_stop_type.html", context={"map_type": map_type})

--- a/SimplyTransport/controllers/realtime.py
+++ b/SimplyTransport/controllers/realtime.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from advanced_alchemy.exceptions import NotFoundError
 from litestar import Controller, get
 from litestar.di import Provide
+from litestar.params import FromPath, FromQuery
 from litestar.response import Template
 
 from SimplyTransport.lib.cache_keys import (
@@ -45,7 +46,7 @@ class RealtimeController(Controller):
     )
     async def realtime_stop(
         self,
-        stop_id: str,
+        stop_id: FromPath[str],
         stop_repo: StopRepository,
         route_repo: RouteRepository,
     ) -> Template:
@@ -79,7 +80,7 @@ class RealtimeController(Controller):
     )
     async def realtime_stop_table(
         self,
-        stop_id: str,
+        stop_id: FromPath[str],
         stop_repo: StopRepository,
         schedule_service: ScheduleService,
         realtime_service: RealTimeService,
@@ -128,9 +129,9 @@ class RealtimeController(Controller):
     )
     async def realtime_stop_schedule(
         self,
-        stop_id: str,
+        stop_id: FromPath[str],
         schedule_service: ScheduleService,
-        day: DayOfWeek | None = None,
+        day: FromQuery[DayOfWeek | None] = None,
     ) -> Template:
         if day is None:
             day = DayOfWeek(datetime.now().weekday())
@@ -155,8 +156,8 @@ class RealtimeController(Controller):
     )
     async def realtime_route(
         self,
-        route_id: str,
-        direction: Direction,
+        route_id: FromPath[str],
+        direction: FromPath[Direction],
         route_repo: RouteRepository,
         stop_repo: StopRepository,
     ) -> Template:
@@ -183,7 +184,7 @@ class RealtimeController(Controller):
     )
     async def realtime_trip(
         self,
-        trip_id: str,
+        trip_id: FromPath[str],
         schedule_service: ScheduleService,
         realtime_service: RealTimeService,
     ) -> Template:

--- a/SimplyTransport/controllers/search.py
+++ b/SimplyTransport/controllers/search.py
@@ -1,10 +1,11 @@
 import math
+from typing import Annotated
 
 from advanced_alchemy.exceptions import NotFoundError
 from advanced_alchemy.filters import LimitOffset
 from litestar import Controller, get
 from litestar.di import Provide
-from litestar.params import Parameter
+from litestar.params import QueryParameter
 from litestar.response import Template
 
 from ..domain.route.repo import RouteRepository, provide_route_repo
@@ -27,9 +28,10 @@ class SearchController(Controller):
         self,
         stop_repo: StopRepository,
         limit_offset: LimitOffset,
-        search: str = Parameter(
-            query="search", required=True, description="Search string to search by name or code"
-        ),
+        search: Annotated[
+            str,
+            QueryParameter(name="search", description="Search string to search by name or code"),
+        ],
     ) -> Template:
         try:
             stops, total = await stop_repo.list_by_name_or_code(search=search, limit_offset=limit_offset)
@@ -57,8 +59,8 @@ class SearchController(Controller):
     @get("/stops/nearby")
     async def stops_nearby(
         self,
-        latitude: float = Parameter(query="latitude", required=True, description="Latitude of the user"),
-        longitude: float = Parameter(query="longitude", required=True, description="Longitude of the user"),
+        latitude: Annotated[float, QueryParameter(name="latitude", description="Latitude of the user")],
+        longitude: Annotated[float, QueryParameter(name="longitude", description="Longitude of the user")],
     ) -> Template:
         return Template(
             "gtfs_search/stop_nearby.html",
@@ -73,9 +75,10 @@ class SearchController(Controller):
         self,
         route_repo: RouteRepository,
         limit_offset: LimitOffset,
-        search: str = Parameter(
-            query="search", required=True, description="Search string to search by name or code"
-        ),
+        search: Annotated[
+            str,
+            QueryParameter(name="search", description="Search string to search by name or code"),
+        ],
     ) -> Template:
         try:
             routes, total = await route_repo.list_by_short_name_or_long_name(

--- a/SimplyTransport/lib/opentelemetry.py
+++ b/SimplyTransport/lib/opentelemetry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 
 import opentelemetry._logs as otel_logs
-from litestar.contrib.opentelemetry import OpenTelemetryConfig, OpenTelemetryPlugin
+from litestar.plugins.opentelemetry import OpenTelemetryConfig, OpenTelemetryPlugin
 from opentelemetry import metrics, trace
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter

--- a/SimplyTransport/lib/parameters/limitoffset.py
+++ b/SimplyTransport/lib/parameters/limitoffset.py
@@ -1,16 +1,12 @@
-from litestar.params import Parameter
-from litestar.repository.filters import LimitOffset
+from typing import Annotated
+
+from advanced_alchemy.filters import LimitOffset
+from litestar.params import QueryParameter
 
 
 async def provide_limit_offset_pagination(
-    current_page: int = Parameter(ge=1, query="currentPage", default=1, required=False),
-    page_size: int = Parameter(
-        query="pageSize",
-        ge=1,
-        le=100,
-        default=20,
-        required=False,
-    ),
+    current_page: Annotated[int, QueryParameter(name="currentPage", ge=1)] = 1,
+    page_size: Annotated[int, QueryParameter(name="pageSize", ge=1, le=100)] = 20,
 ) -> LimitOffset:
     """Add offset/limit pagination.
 

--- a/SimplyTransport/lib/parameters/orderby_shapes.py
+++ b/SimplyTransport/lib/parameters/orderby_shapes.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, cast
+from typing import Annotated, Literal
 
 from advanced_alchemy.filters import OrderBy
 from litestar.params import QueryParameter
@@ -15,7 +15,7 @@ async def provide_order_by_shapes(
         ),
     ] = "sequence",
     sort_order: Annotated[
-        str,
+        Literal["asc", "desc"],
         QueryParameter(
             name="sortOrder",
             examples=[examples.e_asc, examples.e_desc],
@@ -30,13 +30,8 @@ async def provide_order_by_shapes(
     ----------
     field_name : str
         Field to order on.
-    sort_order : str
+    sort_order : Literal["asc", "desc"]
         Direction to sort.
     """
 
-    if sort_order not in ["asc", "desc"]:
-        sort_order = "asc"
-
-    sort_order_literal = cast(Literal["asc", "desc"], sort_order)
-
-    return OrderBy(field_name, sort_order_literal)
+    return OrderBy(field_name, sort_order)

--- a/SimplyTransport/lib/parameters/orderby_shapes.py
+++ b/SimplyTransport/lib/parameters/orderby_shapes.py
@@ -1,21 +1,26 @@
-from typing import Literal, cast
+from typing import Annotated, Literal, cast
 
-from litestar.params import Parameter
-from litestar.repository.filters import OrderBy
+from advanced_alchemy.filters import OrderBy
+from litestar.params import QueryParameter
 
 from . import examples
 
 
 async def provide_order_by_shapes(
-    field_name: str = Parameter(
-        query="orderBy",
-        default="sequence",
-        required=False,
-        examples=[examples.e_sequence, examples.e_distance],
-    ),
-    sort_order: str = Parameter(
-        query="sortOrder", default="asc", required=False, examples=[examples.e_asc, examples.e_desc]
-    ),
+    field_name: Annotated[
+        str,
+        QueryParameter(
+            name="orderBy",
+            examples=[examples.e_sequence, examples.e_distance],
+        ),
+    ] = "sequence",
+    sort_order: Annotated[
+        str,
+        QueryParameter(
+            name="sortOrder",
+            examples=[examples.e_asc, examples.e_desc],
+        ),
+    ] = "asc",
 ) -> OrderBy:
     """Add order by for shapes.
 

--- a/SimplyTransport/lib/parameters/time_query.py
+++ b/SimplyTransport/lib/parameters/time_query.py
@@ -1,0 +1,27 @@
+from datetime import datetime, time
+from typing import Annotated
+
+from litestar.params import PathParameter, QueryParameter
+
+from ...domain.enums import DayOfWeek
+
+StartTimeQuery = Annotated[
+    time | None,
+    QueryParameter(description="Start time, defaults to 10 minutes ago\n\nExample: 10:00:00"),
+]
+EndTimeQuery = Annotated[
+    time | None,
+    QueryParameter(description="End time, defaults to 60 minutes from now\n\nExample: 11:00:00"),
+]
+DayQuery = Annotated[DayOfWeek | None, QueryParameter(description="Day of week, defaults to today")]
+
+ScheduledTimePath = Annotated[time, PathParameter(description="Format: HH:MM:SS")]
+
+StartDateTimeQuery = Annotated[
+    datetime | None,
+    QueryParameter(description="Use data from this time onwards. Format: 2023-10-13T21:34:23Z"),
+]
+EndDateTimeQuery = Annotated[
+    datetime | None,
+    QueryParameter(description="Use data up to this time. Format: 2023-10-13T21:34:23Z"),
+]

--- a/SimplyTransport/lib/template_engine.py
+++ b/SimplyTransport/lib/template_engine.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.template.config import TemplateConfig
 
 from .constants import APP_DIR, TEMPLATE_DIR

--- a/requirements-top-level.txt
+++ b/requirements-top-level.txt
@@ -1,7 +1,7 @@
 advanced_alchemy==1.9.1
 asyncpg==0.31.0
 geojson==3.1.0
-litestar==2.21.1
+litestar==2.22.0
 jinja2==3.1.6
 opentelemetry-api==1.40.0
 opentelemetry-exporter-otlp-proto-common==1.40.0


### PR DESCRIPTION
## Summary by Sourcery

Migrate controllers and parameter helpers to the newer Litestar parameter annotation style and updated pagination/filtering utilities.

Enhancements:
- Refactor API and web controllers to use Annotated-based QueryParameter/PathParameter and FromPath/FromQuery for path and query arguments in line with the newer Litestar version.
- Introduce shared time and date query parameter type aliases for schedule, realtime, and delay endpoints to centralize validation and documentation.
- Update pagination and ordering helpers to use advanced_alchemy LimitOffset and OrderBy filters instead of the previous repository filters.
- Align various route handlers’ type signatures with more explicit path and query parameter typing across the application.