### PR TITLE
update deploy script

### DIFF
--- a/deployment_linux/README.md
+++ b/deployment_linux/README.md
@@ -37,4 +37,4 @@ sudo apt install -y build-essential python3-dev
 
 Then install app dependencies from the project root as usual. With `libpq-dev` installed, a fallback source build of the client can succeed; with a matching **wheel** for your Python version, `psycopg2-binary` installs without compiling.
 
-`deploy.sh` only runs `git pull` and restarts Supervisor; it does not upgrade Python or reinstall dependencies—do that after pulling when you change the runtime version.
+`deploy.sh` runs `git pull`, `uv pip install -r requirements-top-level.txt` into `venv`, then restarts Supervisor. It does not upgrade the Python interpreter—recreate `venv` manually when you change the runtime version (see above).

--- a/deployment_linux/deploy.sh
+++ b/deployment_linux/deploy.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# This script pulls the latest version of the code from the git repository and tells supervisor to reboot the process
-
-restart_supervisor() {
-    echo "Restarting Supervisor..."
-    supervisorctl restart simplytransport
-}
-
-trap restart_supervisor EXIT
+# Pull latest code, sync Python deps, then restart the app via Supervisor
 
 cd /home/niall/SimplyTransport
 git pull
+
+echo "Updating Python dependencies..."
+source venv/bin/activate
+uv pip install -r requirements-top-level.txt
+
+echo "Restarting Supervisor..."
+supervisorctl restart simplytransport


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Clarify the deployment README to describe that deploy.sh now updates dependencies in the virtualenv and note that Python runtime upgrades still require manual venv recreation.